### PR TITLE
Remove faculty of clients to have severals brokers

### DIFF
--- a/lib/Client.js
+++ b/lib/Client.js
@@ -10,11 +10,9 @@ var putils = require('./utils');
 
 var HEARTBEAT_LIVENESS = 3;
 
-function Client(brokers, conf) {
-  if (_.isString(brokers)) {
-    brokers = [brokers];
-  }
-  this.brokers = brokers;
+function Client(broker, conf) {
+
+  this.broker = broker;
 
   this.conf = {
     autostart: false,
@@ -24,7 +22,7 @@ function Client(brokers, conf) {
     retry: 0,
     name: 'C' + uuid.v4()
   };
-  
+
   this.reqs = {};
 
   _.extend(this.conf, conf);
@@ -33,13 +31,13 @@ function Client(brokers, conf) {
 
   if (this.conf.autostart) {
     this.start();
-  } 
+  }
 };
 util.inherits(Client, events.EventEmitter);
 
 Client.prototype.start = function() {
   var self = this;
-  
+
   this.stop();
 
   this.socket = zmq.socket('dealer');
@@ -53,12 +51,10 @@ Client.prototype.start = function() {
     self.emitErr(err);
   });
 
-  _.each(this.brokers, function(b) {
-    self.socket.connect(b);
-  });
-
+  self.socket.connect(this.broker);
+ 
   this.liveness = HEARTBEAT_LIVENESS;
-  
+
   this.emit.apply(this, ['connect']);
 
   debug('C: connected');
@@ -67,7 +63,7 @@ Client.prototype.start = function() {
     _.each(self.reqs, function(req, rid) {
       if (req.timeout > -1 && ((new Date()).getTime() > req.lts + req.timeout)) {
         self.onMsg([
-          MDP.CLIENT, MDP.W_REPLY, '', new Buffer(rid), new Buffer('-1'), 
+          MDP.CLIENT, MDP.W_REPLY, '', new Buffer(rid), new Buffer('-1'),
           new Buffer(JSON.stringify('C_TIMEOUT'))
         ]);
       }
@@ -89,20 +85,15 @@ Client.prototype.start = function() {
 
 Client.prototype.stop = function() {
   var self = this;
-  
+
   clearInterval(this.hbTimer);
 
   if (this.socket) {
     debug('C: disconnected');
 
     this.emit.apply(this, ['disconnect']);
-    
-    _.each(this.brokers, function(b) {
-      self.socket.disconnect(b);
-    });
-   
     this.socket.close();
-    
+
     delete this.socket;
   }
 };
@@ -119,14 +110,14 @@ Client.prototype.onMsg = function(msg) {
 
   var header = msg[0];
   var type = msg[1];
-  
+
   this.liveness = HEARTBEAT_LIVENESS;
 
   if (header != MDP.CLIENT) {
     this.emitErr('ERR_MSG_HEADER');
     return;
   }
-  
+
   if (type == MDP.W_HEARTBEAT) {
     debug('C: HEARTBEAT');
     return;
@@ -200,13 +191,15 @@ function _request(serviceName, data, _opts) {
     heartbeat: function() {
       self.heartbeat(rid);
     },
-    _finalMsg: null, 
+    _finalMsg: null,
     ended: false
   };
 
   req.lts = req.ts;
 
-  var stream = new Readable({ objectMode: true });
+  var stream = new Readable({
+    objectMode: true
+  });
 
   stream._read = noop;
   stream.heartbeat = req.heartbeat;
@@ -216,7 +209,7 @@ function _request(serviceName, data, _opts) {
   debug('C: send request', serviceName, rid);
 
   this.send([
-    MDP.CLIENT, MDP.W_REQUEST, serviceName, rid, 
+    MDP.CLIENT, MDP.W_REQUEST, serviceName, rid,
     JSON.stringify(data), JSON.stringify(opts)
   ]);
 


### PR DESCRIPTION
Hi,

I discussed in #32 , I think we should remove support for multiple brokers.

It appears that this case is not tested, so I guess this is not an important feature.

Calling 'socket.disconnect' is useless since when we call close, [see](http://comments.gmane.org/gmane.network.zeromq.devel/18880).