### PR TITLE
Fix wildcard and add tests

### DIFF
--- a/lib/Broker.js
+++ b/lib/Broker.js
@@ -533,33 +533,24 @@ Broker.prototype.servicesUpdate = function() {
   _.each(this.services, function(service, srvName) {
     service.aux = [srvName];
   });
-    
+
   _.each(this.services, function(service, srvName) {
-    var isWC = srvName[srvName.length - 1] === '*';
-  
-    _.each(self.services, function(aService, aSrvName) {
-      if (aSrvName === srvName) {
-        return;
-      }
+    if (service.workers.length == 0 && srvName[srvName.length - 1] !== '*') {
+      // let's find the best matching widlcard services
 
-      var rel = false;
-      if (isWC) {
-        if(aSrvName.indexOf(srvName.slice(0, -1)) === 0) {
-          rel = true;
-        }
-      } else {
-        var aIsWC = aSrvName[aSrvName.length - 1] === '*';
+      var bestMatching = _.reduce(self.services, function(memo, aService, aSrvName) {
 
-        if (aIsWC && srvName.indexOf(aSrvName.slice(0, -1)) === 0) {
-          rel = true;
-        }
-      }
+        if (aSrvName == srvName || aSrvName[aSrvName.length - 1] !== '*' || srvName.indexOf(aSrvName.slice(0, -1)) !== 0) {
+          return memo;
+        };
 
-      if (rel) {
-        aService.aux.push(srvName);
-        service.aux.push(aSrvName);
-      }
-    });
+        return aSrvName.length > memo.length ? aSrvName : memo;
+      }, "");
+
+      if (bestMatching) {
+        service.aux.push(bestMatching);
+      };
+    }
   });
 
   _.each(this.services, function(service, srvName) {

--- a/test/wildcards.js
+++ b/test/wildcards.js
@@ -1,67 +1,208 @@
 var PIGATO = require('../');
-var chai = require('chai');
+var assert = require('chai').assert;
 var uuid = require('node-uuid');
 
 var location = 'inproc://#';
 
 var bhost = location + uuid.v4();
 var broker = new PIGATO.Broker(bhost);
-   
 
-describe('WILDCARDS', function () {
+var client, worker, ns;
 
-  before(function(done) {
+describe('WILDCARDS', function() {
+
+  beforeEach(function(done) {
     broker.conf.onStart = done;
     broker.start();
   });
 
-  after(function(done) {
+  afterEach(function(done) {
     broker.conf.onStop = done;
     broker.stop();
   });
 
-  it('Base', function (done) {
-    var ns = uuid.v4();
-    this.timeout(5000);
 
-    var client = new PIGATO.Client(bhost);
-    var worker = new PIGATO.Worker(bhost, ns + '*');
+  describe('A wildcard worker', function() {
     var chunk = 'foo';
+    beforeEach(function() {
+      ns = uuid.v4();
+      client = new PIGATO.Client(bhost);
+      worker = new PIGATO.Worker(bhost, ns + '*');
 
-    worker.start();
+      worker.start();
 
-    client.start();
+      client.start();
+      worker.on('request', function(inp, res) {
+        res.end(inp + ':bar');
+      });
 
-    worker.on('request', function(inp, res) {
-      res.end(inp + ':bar');
     });
 
-    var rcnt = 0;
-
-    function request() {
-      client.request(ns + '-' + uuid.v4(), chunk, { timeout: 5000 })
-      .on('data', function(data) {
-        chai.assert.equal(data, chunk + ':bar');
-      })
-      .on('error', function (err) {
-        stop(err);
-      })
-      .on('end', function() {
-        rcnt++;
-        if (rcnt === 5) {
-          stop();
-        }
-      });
-    }
-
-    for (var i = 0; i < 5; i++) {
-      request();
-    }
-
-    function stop(err) {
+    afterEach(function() {
       client.stop();
       worker.stop();
-      done(err);
-    }
-  })
+    })
+
+    it('can be reach several times using widlcard mecanisme', function(done) {
+      this.timeout(5000);
+      var rcnt = 0;
+
+      function request() {
+        client.request(ns + '-' + uuid.v4(), chunk, {
+            timeout: 5000
+          })
+          .on('data', function(data) {
+            assert.equal(data, chunk + ':bar');
+          })
+          .on('error', function(err) {
+            assert.equal(undefined, err);
+            done(err);
+          })
+          .on('end', function() {
+            rcnt++;
+            if (rcnt === 5) {
+              done();
+            }
+          });
+      }
+      for (var i = 0; i < 5; i++) {
+        request();
+      }
+
+    });
+
+    it('Can reach a wildcard worker by using the wildcard name', function(done) {
+
+      client.request(ns + '*', chunk, function() {}, function(type, data) {
+        assert.equal(type, 0);
+        assert.equal(data, chunk + ':bar');
+        done();
+      })
+    });
+  });
+
+
+  describe('When a worker with matching name exist', function() {
+
+    var wildcardWorker, matchingworker, workerid;
+
+    beforeEach(function() {
+      ns = uuid.v4();
+
+      workerid = uuid.v4();
+      wildcardWorker = new PIGATO.Worker(bhost, ns + '-*');
+      matchingworker = new PIGATO.Worker(bhost, ns + '-' + workerid);
+
+      wildcardWorker.on('request', function(inp, res) {
+        res.end('WILDCARD');
+      });
+
+      matchingworker.on('request', function(inp, res) {
+        res.end('MATCHING');
+      });
+
+      client = new PIGATO.Client(bhost);
+
+      wildcardWorker.start();
+      matchingworker.start();
+      client.start();
+
+    })
+
+    afterEach(function() {
+      matchingworker.stop();
+      wildcardWorker.stop();
+      client.stop();
+    });
+
+    it('use it instead of the wildcard', function(done) {
+      client.request(ns + '-' + workerid, '', function() {}, function(type, data) {
+        assert.equal(type, 0);
+        assert.equal(data, 'MATCHING');
+        done();
+      })
+    });
+  });
+
+
+  describe('When several workers exists with different matching length', function() {
+
+    var wildcardWorker, matchingworker, workerid;
+
+    beforeEach(function() {
+      workerid = uuid.v4();
+      wildcardWorker = new PIGATO.Worker(bhost, ns + '-*');
+      matchingworker = new PIGATO.Worker(bhost, ns + '-' + workerid + '-*');
+
+      wildcardWorker.on('request', function(inp, res) {
+        res.end('WILDCARD');
+      });
+
+      matchingworker.on('request', function(inp, res) {
+        res.end('BEST MATCHING');
+      });
+
+      client = new PIGATO.Client(bhost);
+
+      wildcardWorker.start();
+      matchingworker.start();
+      client.start();
+
+    })
+
+    afterEach(function() {
+      matchingworker.stop();
+      wildcardWorker.stop();
+      client.stop();
+    });
+
+    it('use the biggest matching wildcard node', function(done) {
+      client.request(ns + '-' + workerid + '-aa', '', function() {}, function(type, data) {
+        assert.equal(type, 0);
+        assert.equal(data, 'BEST MATCHING');
+        done();
+      })
+    });
+  });
+
+
+  describe('A wildcard worker with a long name but not matching', function() {
+
+    var wildcardWorker, matchingworker, workerid;
+
+    beforeEach(function() {
+      workerid = uuid.v4();
+      wildcardWorker = new PIGATO.Worker(bhost, ns + uuid.v4() + uuid.v4() + '-*');
+      matchingworker = new PIGATO.Worker(bhost, ns + '-' + workerid + '-*');
+
+      wildcardWorker.on('request', function(inp, res) {
+        res.end('WILDCARD');
+      });
+
+      matchingworker.on('request', function(inp, res) {
+        res.end('BEST MATCHING');
+      });
+
+      client = new PIGATO.Client(bhost);
+
+      wildcardWorker.start();
+      matchingworker.start();
+      client.start();
+
+    })
+
+    afterEach(function() {
+      matchingworker.stop();
+      wildcardWorker.stop();
+      client.stop();
+    });
+
+    it('is not used', function(done) {
+      client.request(ns + '-' + workerid + '-aa', '', function() {}, function(type, data) {
+        assert.equal(type, 0);
+        assert.equal(data, 'BEST MATCHING');
+        done();
+      })
+    });
+  });
 });


### PR DESCRIPTION
Hi,

As described in #11, the current implementation of wildcard doesn't fit the initial request.

This PR implement the following mecanismes : 
 - By default use workers without wildcard
 - then choose the worker which is matching the best the requested service.

For creating a wildcard worker, just create a worker whose name __end__ by a *. 
There is not other constraints.
If needed, we can reach a worker using the wildcards names.

Samples:
```
Worker /foo/* can be reach with a request for service /foo/bar or /foo/*
With Worker w1 providing /foo/* and Worker w2 /foo/bar , a request for /foo/bar/baz will reach server w2
With Worker w1 providing /foo/* and Worker w2 /foo/bar/* , a request for /foo/bar/baz will reach server w2
```