### PR TITLE
Adding support for semver resolution of services.

### DIFF
--- a/lib/Broker.js
+++ b/lib/Broker.js
@@ -8,6 +8,7 @@ var events = require('events');
 var zmq = require('zmq');
 var async = require('async');
 var _ = require('lodash');
+var semver = require('semver');
 var MDP = require('./mdp');
 var putils = require('./utils');
 var Queue = require('./q');
@@ -536,7 +537,7 @@ Broker.prototype.serviceRequire = function(srvName) {
     q: new Queue(),
     aux: []
   };
-     
+
   this.services[srvName] = service;
   this.servicesUpdate();
   return service;
@@ -550,7 +551,26 @@ Broker.prototype.servicesUpdate = function() {
   });
 
   _.each(this.services, function(service, srvName) {
-    if (!service.workers.length && srvName[srvName.length - 1] !== '*') {
+    if (srvName.indexOf('@') > 0 && !srvName.match(/@\d+[.]\d+[.]\d+$/)) {
+      // find all satisfying services
+
+      var prefix = srvName.replace(/@([^@]+)$/, '@');
+      var range = srvName.replace(/(^.*@)([^@]+)$/, '$2');
+      var satisfying = _.filter(self.services, function (aService, aSrvName) {
+        if (aSrvName == srvName || aSrvName.indexOf(prefix) !== 0 || !aSrvName.match(/@\d+[.]\d+[.]\d+$/)) {
+          return false;
+        }
+
+        var version = aSrvName.replace(/^.+@([^@]+)$/, '$1');
+        return semver.satisfies(version, range);
+      });
+
+      service.aux = _.pluck(satisfying, 'name');
+    }
+  });
+
+  _.each(this.services, function(service, srvName) {
+    if (!service.workers.length && srvName[srvName.length - 1] !== '*' && srvName.indexOf('@') === -1) {
       // let's find the best matching widlcard services
 
       var bestMatching = _.reduce(self.services, function(acc, aService, aSrvName) {

--- a/package.json
+++ b/package.json
@@ -19,8 +19,9 @@
     "async": "~1.4.2",
     "debug": "~2.0.0",
     "lodash": "~3.10.1",
-    "readable-stream": "~2.0.2",
     "node-uuid": "~1.4.2",
+    "readable-stream": "~2.0.2",
+    "semver": "^5.0.3",
     "zmq": "~2.13.0"
   },
   "engine": {

--- a/test/semver.js
+++ b/test/semver.js
@@ -1,0 +1,88 @@
+var PIGATO = require('../');
+var chai = require('chai');
+var uuid = require('node-uuid');
+
+var location = 'inproc://#';
+var bhost = location + uuid.v4();
+
+var broker = new PIGATO.Broker(bhost);
+
+
+describe('SEMVER', function() {
+  before(function(done) {
+    broker.conf.onStart = done;
+    broker.start();
+  });
+
+  after(function(done) {
+    broker.conf.onStop = done;
+    broker.stop();
+  });
+
+  it('allows services with semver in name', function(done) {
+    var ns = uuid.v4() + '@1.2.3';
+    this.timeout(5000);
+
+    var client = new PIGATO.Client(bhost);
+
+    var worker = new PIGATO.Worker(bhost, ns);
+    worker.on('request', function(inp, rep) {
+      rep.end(worker.conf.name);
+    });
+    worker.start();
+
+    client.start();
+
+    var workerId = worker.conf.name;
+    client.request(ns, 'foo')
+    .on('data', function(data) {
+        chai.assert.equal(data, workerId);
+      })
+      .on('error', function(err) {
+        stop(err);
+      })
+      .on('end', function() {
+        stop();
+      });
+
+    function stop(err) {
+      worker.stop();
+      client.stop();
+      done(err);
+    }
+  });
+
+  it('can resolve services using semver', function(done) {
+    var namePrefix = uuid.v4();
+    var ns = namePrefix + '@1.2.3';
+    this.timeout(5000);
+
+    var client = new PIGATO.Client(bhost);
+
+    var worker = new PIGATO.Worker(bhost, ns);
+    worker.on('request', function(inp, rep) {
+      rep.end(worker.conf.name);
+    });
+    worker.start();
+
+    client.start();
+
+    var workerId = worker.conf.name;
+    client.request(namePrefix + '@^1.2.x', 'foo')
+    .on('data', function(data) {
+      chai.assert.equal(data, workerId);
+    })
+    .on('error', function(err) {
+      stop(err);
+    })
+    .on('end', function() {
+      stop();
+    });
+
+    function stop(err) {
+      worker.stop();
+      client.stop();
+      done(err);
+    }
+  });
+});


### PR DESCRIPTION
Allows you to create versioned services and then resolving them by using semver ranges.

For example:
Worker#1 a@1.2.3
Worker#2 a@1.2.4

Clients can declare that they require a@~1.2.3 and either of those will match.