### PR TITLE
Remove Listeners from socket that is closed

### DIFF
--- a/lib/Worker.js
+++ b/lib/Worker.js
@@ -107,6 +107,12 @@ Worker.prototype.stop = function() {
     this.sendDisconnect();
     
     var socket = this.socket;
+    
+    // Unless this is done, stopping the broker will cause a W_DISCONNECT to be sent to this
+    // Worker, resulting in the worker restarting.
+    socket.removeAllListeners('message');
+    socket.removeAllListeners('error');
+    
     delete this.socket;
     
     setImmediate(function() {


### PR DESCRIPTION
It's clear that the delete this.socket line is meant to get rid of the socket, but the socket is still active.

If the broker is closed immediately after that line, the socket will receive a W_DISCONNECT message and it'll restart the worker, even though the programmer has explicitly stopped it.