### PR TITLE
Fix for zmq closed sockets not being reusable

### DIFF
--- a/lib/Worker.js
+++ b/lib/Worker.js
@@ -55,6 +55,9 @@ Worker.prototype.start = function() {
   this._mcnt = 0;
 
   this.socket = zmq.socket('dealer');
+
+  this.conf.name = 'W' + uuid.v4();
+
   this.socket.identity = new Buffer(this.conf.name);
   this.socket.setsockopt('linger', 1);
 
@@ -108,7 +111,7 @@ Worker.prototype.stop = function() {
     
     var socket = this.socket;
     delete this.socket;
-    
+
     setImmediate(function() {
       if (socket._zmq.state != zmq.STATE_CLOSED) {
         socket.close();

--- a/test/concurrency.js
+++ b/test/concurrency.js
@@ -2,9 +2,9 @@ var PIGATO = require('../');
 var chai = require('chai');
 var uuid = require('node-uuid');
 
-var location = 'inproc://#';
+//var bhost = 'inproc://#' + uuid.v4();
+var bhost = 'tcp://0.0.0.0:2020';
 
-var bhost = location + uuid.v4();
 var broker = new PIGATO.Broker(bhost);
 
 describe('CONCURRENCY', function () {

--- a/test/directory.js
+++ b/test/directory.js
@@ -2,9 +2,8 @@ var PIGATO = require('../');
 var chai = require('chai');
 var uuid = require('node-uuid');
 
-var location = 'inproc://#';
-
-var bhost = location + uuid.v4();
+//var bhost = 'inproc://#' + uuid.v4();
+var bhost = 'tcp://0.0.0.0:2020';
 
 var broker;
 var ds;

--- a/test/index.js
+++ b/test/index.js
@@ -2,9 +2,8 @@ var PIGATO = require('../');
 var chai = require('chai');
 var uuid = require('node-uuid');
 
-var location = 'inproc://#';
-
-var bhost = location + uuid.v4();
+//var bhost = 'inproc://#' + uuid.v4();
+var bhost = 'tcp://0.0.0.0:2020';
 
 var broker = new PIGATO.Broker(bhost)
 

--- a/test/requestStream.js
+++ b/test/requestStream.js
@@ -2,9 +2,9 @@ var PIGATO = require('../');
 var chai = require('chai');
 var uuid = require('node-uuid');
 
-var location = 'inproc://#';
+//var bhost = 'inproc://#' + uuid.v4();
+var bhost = 'tcp://0.0.0.0:2020';
 
-var bhost = location + uuid.v4();
 var broker = new PIGATO.Broker(bhost);
 
 describe('STREAM SPECS', function() {

--- a/test/semver.js
+++ b/test/semver.js
@@ -2,8 +2,8 @@ var PIGATO = require('../');
 var chai = require('chai');
 var uuid = require('node-uuid');
 
-var location = 'inproc://#';
-var bhost = location + uuid.v4();
+//var bhost = 'inproc://#' + uuid.v4();
+var bhost = 'tcp://0.0.0.0:2020';
 
 var broker = new PIGATO.Broker(bhost);
 

--- a/test/startStop.js
+++ b/test/startStop.js
@@ -4,10 +4,8 @@ var chai = require('chai'),
   assert = chai.assert;
 var uuid = require('node-uuid');
 
-
-var location = 'inproc://#';
-
-var bhost = location + uuid.v4();
+//var bhost = 'inproc://#' + uuid.v4();
+var bhost = 'tcp://0.0.0.0:2020';
 
 var broker = new PIGATO.Broker(bhost, {
   heartbeat: 10000

--- a/test/target.js
+++ b/test/target.js
@@ -2,8 +2,8 @@ var PIGATO = require('../');
 var chai = require('chai');
 var uuid = require('node-uuid');
 
-var location = 'inproc://#';
-var bhost = location + uuid.v4();
+//var bhost = 'inproc://#' + uuid.v4();
+var bhost = 'tcp://0.0.0.0:2020';
 
 var broker = new PIGATO.Broker(bhost);
    

--- a/test/wildcards.js
+++ b/test/wildcards.js
@@ -2,9 +2,8 @@ var PIGATO = require('../');
 var assert = require('chai').assert;
 var uuid = require('node-uuid');
 
-var location = 'inproc://#';
-
-var bhost = location + uuid.v4();
+//var bhost = 'inproc://#' + uuid.v4();
+var bhost = 'tcp://0.0.0.0:2020';
 var broker = new PIGATO.Broker(bhost);
 
 var client, worker, ns;

--- a/test/z9_system.js
+++ b/test/z9_system.js
@@ -5,9 +5,8 @@ var uuid = require('node-uuid');
 
 var assert = chai.assert;
 
-var location = 'inproc://#';
-
-var bhost = location + uuid.v4();
+//var bhost = 'inproc://#' + uuid.v4();
+var bhost = 'tcp://0.0.0.0:2020';
 
 var broker = new PIGATO.Broker(bhost);
 


### PR DESCRIPTION
Unfortunately, it appears zmq silently drops messages from sockets that have the same identity as sockets which have been closed before.

This commit makes the the tests use tcp connections to the broker and makes the minimal change required to make them pass.

Fixes Issue #60 and partially fixes #59 