### PR TITLE
eslinting

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -18,6 +18,10 @@
     "semi": [
       2,
       "always"
+    ],
+    "space-before-function-paren": [
+      2,
+      "never"
     ]
   },
   "env": {

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,25 +1,28 @@
 {
-    "rules": {
-        "indent": [
-            2,
-            2 
-        ],
-        "quotes": [
-            2,
-            "single"
-        ],
-        "linebreak-style": [
-            2,
-            "unix"
-        ],
-        "semi": [
-            2,
-            "always"
-        ]
-    },
-    "env": {
-        "node": true,
-        "mocha": true
-    },
-    "extends": "eslint:recommended"
+  "rules": {
+    "indent": [
+      2,
+      2,
+      {
+        "SwitchCase": 1
+      }
+    ],
+    "quotes": [
+      2,
+      "single"
+    ],
+    "linebreak-style": [
+      2,
+      "unix"
+    ],
+    "semi": [
+      2,
+      "always"
+    ]
+  },
+  "env": {
+    "node": true,
+    "mocha": true
+  },
+  "extends": "eslint:recommended"
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,25 @@
+{
+    "rules": {
+        "indent": [
+            2,
+            2 
+        ],
+        "quotes": [
+            2,
+            "single"
+        ],
+        "linebreak-style": [
+            2,
+            "unix"
+        ],
+        "semi": [
+            2,
+            "always"
+        ]
+    },
+    "env": {
+        "node": true,
+        "mocha": true
+    },
+    "extends": "eslint:recommended"
+}

--- a/lib/Broker.js
+++ b/lib/Broker.js
@@ -2,7 +2,6 @@
 
 var util = require('util');
 var debug = require('debug')('pigato:Broker');
-var crypto = require('crypto');
 var uuid = require('node-uuid');
 var events = require('events');
 var zmq = require('zmq');
@@ -17,8 +16,6 @@ var BaseController = require('./BrokerController');
 
 var HEARTBEAT_LIVENESS = 3;
 
-var noop = function() {};
-
 function Broker(endpoint, conf) {
   this.services = {};
   this.workers = {};
@@ -32,7 +29,7 @@ function Broker(endpoint, conf) {
   };
 
   _.extend(this.conf, conf);
-  
+
   this.endpoint = endpoint;
 
   if (this.conf.ctrl) {
@@ -45,7 +42,7 @@ function Broker(endpoint, conf) {
 }
 util.inherits(Broker, events.EventEmitter);
 
-Broker.prototype.start = function() {
+Broker.prototype.start = function () {
   this.socket = zmq.socket('router');
   this.socket.identity = this.conf.name;
   this.socket.setsockopt('linger', 1);
@@ -55,19 +52,19 @@ Broker.prototype.start = function() {
 
   var self = this;
 
-  this.socket.on('message', function() {
+  this.socket.on('message', function () {
     var args = putils.args(arguments);
     self.onMsg.call(self, args);
   });
 
-  this.hbTimer = setInterval(function() {
+  this.hbTimer = setInterval(function () {
     self.workersCheck();
   }, this.conf.heartbeat);
 
-  this.srvTimer = setInterval(function() {
+  this.srvTimer = setInterval(function () {
     var supd = false;
 
-    _.each(self.services, function(service, srvName) {
+    _.each(self.services, function (service, srvName) {
       if (!service.workers.length) {
         supd = true;
         delete self.services[srvName];
@@ -78,60 +75,60 @@ Broker.prototype.start = function() {
       self.servicesUpdate();
     }
 
-    _.each(self.reqs, function(rid, req) {
+    _.each(self.reqs, function (rid, req) {
       var vld = self.requestValidate(req);
       if (!vld) {
         self.requestDelete(req);
       }
     });
   }, 60000);
-  
+
   var queue = [];
 
-  queue.push(function(next) {
-    self.socket.bind(self.endpoint, function() {
-      next();                   
-    });
-  });
-    
-  queue.push(function(next) {
-    self.pub.bind(self.conf.intch, function(err) {
+  queue.push(function (next) {
+    self.socket.bind(self.endpoint, function () {
       next();
     });
   });
 
-  queue.push(function(next) {
-    self.ctrl.rgetall(function(err, reqs) {
-      _.each(reqs, function(req) {
+  queue.push(function (next) {
+    self.pub.bind(self.conf.intch, function () {
+      next();
+    });
+  });
+
+  queue.push(function (next) {
+    self.ctrl.rgetall(function (err, reqs) {
+      _.each(reqs, function (req) {
         self.requestProcess(req);
       });
       next();
     });
   });
 
-  async.series(queue, function() {
+  async.series(queue, function () {
     debug('B: broker started on %s', self.endpoint);
     setImmediate(self.onStart.bind(self));
   });
 };
 
-Broker.prototype.stop = function() {
+Broker.prototype.stop = function () {
   var self = this;
-  
+
   clearInterval(this.hbTimer);
   clearInterval(this.srvTimer);
 
   var queue = [];
 
-  queue.push(function(next) {
-    setTimeout(function() {
+  queue.push(function (next) {
+    setTimeout(function () {
       next();
     }, 100);
   });
 
   if (self.socket) {
-    queue.push(function(next) {
-      self.socket.unbind(self.endpoint, function() {
+    queue.push(function (next) {
+      self.socket.unbind(self.endpoint, function () {
         self.socket.close();
         delete self.socket;
         next();
@@ -140,8 +137,8 @@ Broker.prototype.stop = function() {
   }
 
   if (self.pub) {
-    queue.push(function(next) {
-      self.pub.unbind(self.conf.intch, function() {
+    queue.push(function (next) {
+      self.pub.unbind(self.conf.intch, function () {
         self.pub.close();
         delete self.pub;
         next();
@@ -149,38 +146,37 @@ Broker.prototype.stop = function() {
     });
   }
 
-  async.series(queue, function() {
-    delete self.socket;  
-    delete self.pub ;
+  async.series(queue, function () {
+    delete self.socket;
+    delete self.pub;
 
     setImmediate(self.onStop.bind(self));
   });
 };
 
-Broker.prototype.onStart = function() {
+Broker.prototype.onStart = function () {
   if (this.conf.onStart) {
     this.conf.onStart();
   }
   this.emit('start');
 };
 
-Broker.prototype.onStop = function() {
+Broker.prototype.onStop = function () {
   if (this.conf.onStop) {
     this.conf.onStop();
   }
   this.emit('stop');
 };
 
-Broker.prototype.send = function(msg) {
-  if(!this.socket) {
+Broker.prototype.send = function (msg) {
+  if (!this.socket) {
     return;
   }
 
-  this.socket.send(msg);    
+  this.socket.send(msg);
 };
 
-Broker.prototype.onMsg = function(_msg) {
-  var self = this;
+Broker.prototype.onMsg = function (_msg) {
   var msg = putils.mparse(_msg);
 
   var header = msg[1];
@@ -192,33 +188,37 @@ Broker.prototype.onMsg = function(_msg) {
   } else {
     this.emitErr('ERR_MSG_HEADER');
   }
-  
+
   this.workersCheck();
 };
 
-Broker.prototype.emitErr = function(msg) {
-  this.emit.apply(self, ['error', msg]);
+Broker.prototype.emitErr = function (msg) {
+  this.emit.apply(this, ['error', msg]);
 };
 
-Broker.prototype.onClient = function(msg) {
-  var self = this;
-
+Broker.prototype.onClient = function (msg) {
   var clientId = msg[0];
   var type = msg[2];
 
+  var req;
+  var rid;
   if (type == MDP.W_REQUEST) {
     var srvName = msg[3] || 'UNK';
-    var rid = msg[4];
+    rid = msg[4];
     debug('B: REQUEST from clientId: %s, service: %s', clientId, srvName);
 
     var opts = msg[6];
 
-    try { opts = JSON.parse(opts); } catch(e) {}
+    try {
+      opts = JSON.parse(opts);
+    } catch (e) {
+      // Ignore
+    }
     if (!_.isObject(opts)) {
       opts = {};
     }
 
-    var req = {
+    req = {
       service: srvName,
       clientId: clientId,
       attempts: 0,
@@ -231,10 +231,10 @@ Broker.prototype.onClient = function(msg) {
     };
 
     this.requestProcess(req);
-  } else if (type == MDP.W_HEARTBEAT) {
+  } else if (type == MDP.W_HEARTBEAT) {
     if (msg.length === 4) {
-      var rid = msg[3];
-      var req = this.rmap[rid];
+      rid = msg[3];
+      req = this.rmap[rid];
       if (req && req.workerId) {
         this.send([req.workerId, MDP.WORKER, MDP.W_HEARTBEAT, clientId, '', rid]);
       }
@@ -244,13 +244,15 @@ Broker.prototype.onClient = function(msg) {
   }
 };
 
-Broker.prototype.onWorker = function(msg) {
-  var self = this;
+Broker.prototype.onWorker = function (msg) {
   var workerId = msg[0];
   var type = msg[2];
 
   var wready = (workerId in this.workers);
   var worker = this.workerRequire(workerId);
+
+  var opts;
+
 
   if (type == MDP.W_READY) {
     var srvName = msg[3];
@@ -263,11 +265,11 @@ Broker.prototype.onWorker = function(msg) {
     } else if (!wready) {
       this.serviceRequire(srvName);
       this.serviceWorkerAdd(srvName, workerId);
-      
+
       this.send([workerId, MDP.WORKER, MDP.W_READY]);
     }
     return;
-  } 
+  }
 
   if (!wready) {
     this.workerDelete(workerId, true);
@@ -277,7 +279,6 @@ Broker.prototype.onWorker = function(msg) {
   worker.liveness = HEARTBEAT_LIVENESS;
 
   if (type == MDP.W_REPLY || type == MDP.W_REPLY_PARTIAL || type == MDP.W_REPLY_REJECT) {
-    var clientId = msg[3];
     var rid = msg[5];
 
     if (_.indexOf(worker.rids, rid) === -1) {
@@ -292,7 +293,7 @@ Broker.prototype.onWorker = function(msg) {
       this.workerDelete(workerId, true);
       return;
     }
-  
+
     var service = this.serviceRequire(req.service);
 
     if (type == MDP.W_REPLY_REJECT) {
@@ -308,8 +309,12 @@ Broker.prototype.onWorker = function(msg) {
     } else if (type == MDP.W_REPLY || type == MDP.W_REPLY_PARTIAL) {
       debug('B: REPLY from worker \'%s\' (%s)', workerId, worker.service);
 
-      var opts = msg[8];
-      try { opts = JSON.parse(opts); } catch(e) {}
+      opts = msg[8];
+      try {
+        opts = JSON.parse(opts);
+      } catch (e) {
+        // Ignore
+      }
       if (!_.isObject(opts)) {
         opts = {};
       }
@@ -326,19 +331,19 @@ Broker.prototype.onWorker = function(msg) {
     }
 
   } else if (type == MDP.W_HEARTBEAT) {
-    var opts = msg[4];
-    try { 
-      opts = JSON.parse(opts); 
-    } catch(e) {
+    opts = msg[4];
+    try {
+      opts = JSON.parse(opts);
+    } catch (e) {
       opts = {};
     }
-    
-    _.each(['concurrency'], function(fld) {
+
+    _.each(['concurrency'], function (fld) {
       if (!_.isUndefined(opts[fld])) {
         worker.opts[fld] = opts[fld];
       }
     });
-    
+
     worker.liveness++;
     this.send([workerId, MDP.WORKER, MDP.W_HEARTBEAT]);
 
@@ -353,14 +358,14 @@ Broker.prototype.onWorker = function(msg) {
   }
 };
 
-Broker.prototype.reply = function(type, req, msg) {
+Broker.prototype.reply = function (type, req, msg) {
   this.send([req.clientId, MDP.CLIENT, type, '', req.rid].concat(msg));
 };
 
-Broker.prototype.requestProcess = function(req) {
+Broker.prototype.requestProcess = function (req) {
   var service = this.serviceRequire(req.service);
-  
-  this.rmap[req.rid] = req; 
+
+  this.rmap[req.rid] = req;
   if (req.opts.persist) {
     this.ctrl.rset(req);
   }
@@ -369,7 +374,7 @@ Broker.prototype.requestProcess = function(req) {
   this.dispatch(req.service);
 };
 
-Broker.prototype.requestDelete = function(req) {
+Broker.prototype.requestDelete = function (req) {
   if (!req) {
     return;
   }
@@ -380,7 +385,7 @@ Broker.prototype.requestDelete = function(req) {
   }
 };
 
-Broker.prototype.requestValidate = function(req) {
+Broker.prototype.requestValidate = function (req) {
   if (!req) {
     return false;
   }
@@ -390,9 +395,9 @@ Broker.prototype.requestValidate = function(req) {
   }
 
   return true;
-};	
+};
 
-Broker.prototype.workerRequire = function(workerId) {
+Broker.prototype.workerRequire = function (workerId) {
   if (this.workers[workerId]) {
     return this.workers[workerId];
   }
@@ -412,9 +417,7 @@ Broker.prototype.workerRequire = function(workerId) {
   return worker;
 };
 
-Broker.prototype.workerDelete = function(workerId, disconnect) {
-  var self = this;
-
+Broker.prototype.workerDelete = function (workerId, disconnect) {
   var worker = this.workers[workerId];
 
   if (!worker) {
@@ -464,7 +467,7 @@ Broker.prototype.workerDelete = function(workerId, disconnect) {
       dservices.push(req.service);
     }
   }
-  
+
   this.notify('$dir');
 
   if (dservices.length) {
@@ -474,7 +477,7 @@ Broker.prototype.workerDelete = function(workerId, disconnect) {
   }
 };
 
-Broker.prototype.workersCheck = function() {
+Broker.prototype.workersCheck = function () {
   var self = this;
 
   if (this._wcheck) {
@@ -485,7 +488,7 @@ Broker.prototype.workersCheck = function() {
 
   this._wcheck = (new Date()).getTime();
 
-  _.each(this.workers, function(worker, workerId) {
+  _.each(this.workers, function (worker, workerId) {
     if (!worker) {
       self.workerDelete(workerId, true);
       return;
@@ -499,13 +502,13 @@ Broker.prototype.workersCheck = function() {
       return;
     }
 
-    if(worker.liveness < HEARTBEAT_LIVENESS){ 
+    if (worker.liveness < HEARTBEAT_LIVENESS) {
       self.send([workerId, MDP.WORKER, MDP.W_HEARTBEAT]);
     }
   });
 };
 
-Broker.prototype.workerAvailable = function(workerId) {
+Broker.prototype.workerAvailable = function (workerId) {
   if (!workerId) {
     return false;
   }
@@ -514,7 +517,7 @@ Broker.prototype.workerAvailable = function(workerId) {
   if (!worker) {
     return false;
   }
-  
+
   if (worker.opts.concurrency === -1) {
     return true;
   }
@@ -526,7 +529,7 @@ Broker.prototype.workerAvailable = function(workerId) {
   return false;
 };
 
-Broker.prototype.serviceRequire = function(srvName) {
+Broker.prototype.serviceRequire = function (srvName) {
   if (this.services[srvName]) {
     return this.services[srvName];
   }
@@ -543,14 +546,14 @@ Broker.prototype.serviceRequire = function(srvName) {
   return service;
 };
 
-Broker.prototype.servicesUpdate = function() {
+Broker.prototype.servicesUpdate = function () {
   var self = this;
 
-  _.each(this.services, function(service, srvName) {
+  _.each(this.services, function (service, srvName) {
     service.aux = [srvName];
   });
 
-  _.each(this.services, function(service, srvName) {
+  _.each(this.services, function (service, srvName) {
     if (srvName.indexOf('@') > 0 && !srvName.match(/@\d+[.]\d+[.]\d+$/)) {
       // find all satisfying services
 
@@ -569,11 +572,11 @@ Broker.prototype.servicesUpdate = function() {
     }
   });
 
-  _.each(this.services, function(service, srvName) {
+  _.each(this.services, function (service, srvName) {
     if (!service.workers.length && srvName[srvName.length - 1] !== '*' && srvName.indexOf('@') === -1) {
       // let's find the best matching widlcard services
 
-      var bestMatching = _.reduce(self.services, function(acc, aService, aSrvName) {
+      var bestMatching = _.reduce(self.services, function (acc, aService, aSrvName) {
 
         if (aSrvName == srvName || aSrvName[aSrvName.length - 1] !== '*' || srvName.indexOf(aSrvName.slice(0, -1)) !== 0) {
           return acc;
@@ -588,7 +591,7 @@ Broker.prototype.servicesUpdate = function() {
     }
   });
 
-  _.each(this.services, function(service, srvName) {
+  _.each(this.services, function (service, srvName) {
     service.aux = _.unique(service.aux);
     if (!service.aux.length) {
       delete self.services[srvName];
@@ -596,7 +599,7 @@ Broker.prototype.servicesUpdate = function() {
   });
 };
 
-Broker.prototype.serviceWorkerAdd = function(srvName, workerId) {
+Broker.prototype.serviceWorkerAdd = function (srvName, workerId) {
   var service = this.serviceRequire(srvName);
   var worker = this.workerRequire(workerId);
 
@@ -618,7 +621,7 @@ function _rhandle(srvName, workerIds) {
   var self = this;
 
   var service = this.serviceRequire(srvName);
-  
+
   var rid = service.q.dequeue();
   if (!rid) {
     return 0;
@@ -628,9 +631,9 @@ function _rhandle(srvName, workerIds) {
   if (!req) {
     return 0;
   }
- 
+
   var vld = this.requestValidate(req);
-  
+
   if (!vld) {
     delete this.rmap[req.rid];
     if (req.opts.persist) {
@@ -639,9 +642,9 @@ function _rhandle(srvName, workerIds) {
 
     return service.q.getLength();
   }
-  
+
   req.attempts++;
- 
+
   var workerId = null;
   var wcret = 0;
 
@@ -669,9 +672,9 @@ function _rhandle(srvName, workerIds) {
     service.q.enqueue(req.rid);
     return wcret;
   }
- 
+
   var worker = this.workerRequire(workerId);
-  
+
   req.workerId = worker.workerId;
   worker.rids.push(req.rid);
   worker.rcnt++;
@@ -681,16 +684,16 @@ function _rhandle(srvName, workerIds) {
   }
 
   var obj = [
-    worker.workerId, MDP.WORKER, MDP.W_REQUEST, 
+    worker.workerId, MDP.WORKER, MDP.W_REQUEST,
     req.clientId, req.service, ''
   ].concat(req.msg.slice(4));
 
   this.send(obj);
-  
+
   return 1;
 }
 
-Broker.prototype.dispatch = function(srvName) {
+Broker.prototype.dispatch = function (srvName) {
   var self = this;
   var service = this.serviceRequire(srvName);
   var qlen = service.q.getLength();
@@ -706,7 +709,7 @@ Broker.prototype.dispatch = function(srvName) {
   }
 
   if (this.conf.dmode === 'load' && workerIds.length > 1) {
-    workerIds.sort(function(a, b) {
+    workerIds.sort(function (a, b) {
       var wa = self.workers[a];
       var wb = self.workers[b];
       var arn = wa.rids.length;
@@ -732,16 +735,16 @@ Broker.prototype.dispatch = function(srvName) {
   }
 };
 
-Broker.prototype.notify = function(channel) {
+Broker.prototype.notify = function (channel) {
   switch (channel) {
-  case '$dir':
-    this.pub.send('$dir ' + JSON.stringify(
-        _.reduce(this.services, function(acc, service, srvName) {
+    case '$dir':
+      this.pub.send('$dir ' + JSON.stringify(
+        _.reduce(this.services, function (acc, service, srvName) {
           acc[srvName] = service.workers;
-          return acc; 
+          return acc;
         }, {})
       ));
-    break;
+      break;
   }
 };
 

--- a/lib/Broker.js
+++ b/lib/Broker.js
@@ -42,7 +42,7 @@ function Broker(endpoint, conf) {
 }
 util.inherits(Broker, events.EventEmitter);
 
-Broker.prototype.start = function () {
+Broker.prototype.start = function() {
   this.socket = zmq.socket('router');
   this.socket.identity = this.conf.name;
   this.socket.setsockopt('linger', 1);
@@ -52,19 +52,19 @@ Broker.prototype.start = function () {
 
   var self = this;
 
-  this.socket.on('message', function () {
+  this.socket.on('message', function() {
     var args = putils.args(arguments);
     self.onMsg.call(self, args);
   });
 
-  this.hbTimer = setInterval(function () {
+  this.hbTimer = setInterval(function() {
     self.workersCheck();
   }, this.conf.heartbeat);
 
-  this.srvTimer = setInterval(function () {
+  this.srvTimer = setInterval(function() {
     var supd = false;
 
-    _.each(self.services, function (service, srvName) {
+    _.each(self.services, function(service, srvName) {
       if (!service.workers.length) {
         supd = true;
         delete self.services[srvName];
@@ -75,7 +75,7 @@ Broker.prototype.start = function () {
       self.servicesUpdate();
     }
 
-    _.each(self.reqs, function (rid, req) {
+    _.each(self.reqs, function(rid, req) {
       var vld = self.requestValidate(req);
       if (!vld) {
         self.requestDelete(req);
@@ -85,34 +85,34 @@ Broker.prototype.start = function () {
 
   var queue = [];
 
-  queue.push(function (next) {
-    self.socket.bind(self.endpoint, function () {
+  queue.push(function(next) {
+    self.socket.bind(self.endpoint, function() {
       next();
     });
   });
 
-  queue.push(function (next) {
-    self.pub.bind(self.conf.intch, function () {
+  queue.push(function(next) {
+    self.pub.bind(self.conf.intch, function() {
       next();
     });
   });
 
-  queue.push(function (next) {
-    self.ctrl.rgetall(function (err, reqs) {
-      _.each(reqs, function (req) {
+  queue.push(function(next) {
+    self.ctrl.rgetall(function(err, reqs) {
+      _.each(reqs, function(req) {
         self.requestProcess(req);
       });
       next();
     });
   });
 
-  async.series(queue, function () {
+  async.series(queue, function() {
     debug('B: broker started on %s', self.endpoint);
     setImmediate(self.onStart.bind(self));
   });
 };
 
-Broker.prototype.stop = function () {
+Broker.prototype.stop = function() {
   var self = this;
 
   clearInterval(this.hbTimer);
@@ -120,15 +120,15 @@ Broker.prototype.stop = function () {
 
   var queue = [];
 
-  queue.push(function (next) {
-    setTimeout(function () {
+  queue.push(function(next) {
+    setTimeout(function() {
       next();
     }, 100);
   });
 
   if (self.socket) {
-    queue.push(function (next) {
-      self.socket.unbind(self.endpoint, function () {
+    queue.push(function(next) {
+      self.socket.unbind(self.endpoint, function() {
         self.socket.close();
         delete self.socket;
         next();
@@ -137,8 +137,8 @@ Broker.prototype.stop = function () {
   }
 
   if (self.pub) {
-    queue.push(function (next) {
-      self.pub.unbind(self.conf.intch, function () {
+    queue.push(function(next) {
+      self.pub.unbind(self.conf.intch, function() {
         self.pub.close();
         delete self.pub;
         next();
@@ -146,7 +146,7 @@ Broker.prototype.stop = function () {
     });
   }
 
-  async.series(queue, function () {
+  async.series(queue, function() {
     delete self.socket;
     delete self.pub;
 
@@ -154,21 +154,21 @@ Broker.prototype.stop = function () {
   });
 };
 
-Broker.prototype.onStart = function () {
+Broker.prototype.onStart = function() {
   if (this.conf.onStart) {
     this.conf.onStart();
   }
   this.emit('start');
 };
 
-Broker.prototype.onStop = function () {
+Broker.prototype.onStop = function() {
   if (this.conf.onStop) {
     this.conf.onStop();
   }
   this.emit('stop');
 };
 
-Broker.prototype.send = function (msg) {
+Broker.prototype.send = function(msg) {
   if (!this.socket) {
     return;
   }
@@ -176,7 +176,7 @@ Broker.prototype.send = function (msg) {
   this.socket.send(msg);
 };
 
-Broker.prototype.onMsg = function (_msg) {
+Broker.prototype.onMsg = function(_msg) {
   var msg = putils.mparse(_msg);
 
   var header = msg[1];
@@ -192,11 +192,11 @@ Broker.prototype.onMsg = function (_msg) {
   this.workersCheck();
 };
 
-Broker.prototype.emitErr = function (msg) {
+Broker.prototype.emitErr = function(msg) {
   this.emit.apply(this, ['error', msg]);
 };
 
-Broker.prototype.onClient = function (msg) {
+Broker.prototype.onClient = function(msg) {
   var clientId = msg[0];
   var type = msg[2];
 
@@ -244,7 +244,7 @@ Broker.prototype.onClient = function (msg) {
   }
 };
 
-Broker.prototype.onWorker = function (msg) {
+Broker.prototype.onWorker = function(msg) {
   var workerId = msg[0];
   var type = msg[2];
 
@@ -338,7 +338,7 @@ Broker.prototype.onWorker = function (msg) {
       opts = {};
     }
 
-    _.each(['concurrency'], function (fld) {
+    _.each(['concurrency'], function(fld) {
       if (!_.isUndefined(opts[fld])) {
         worker.opts[fld] = opts[fld];
       }
@@ -358,11 +358,11 @@ Broker.prototype.onWorker = function (msg) {
   }
 };
 
-Broker.prototype.reply = function (type, req, msg) {
+Broker.prototype.reply = function(type, req, msg) {
   this.send([req.clientId, MDP.CLIENT, type, '', req.rid].concat(msg));
 };
 
-Broker.prototype.requestProcess = function (req) {
+Broker.prototype.requestProcess = function(req) {
   var service = this.serviceRequire(req.service);
 
   this.rmap[req.rid] = req;
@@ -374,7 +374,7 @@ Broker.prototype.requestProcess = function (req) {
   this.dispatch(req.service);
 };
 
-Broker.prototype.requestDelete = function (req) {
+Broker.prototype.requestDelete = function(req) {
   if (!req) {
     return;
   }
@@ -385,7 +385,7 @@ Broker.prototype.requestDelete = function (req) {
   }
 };
 
-Broker.prototype.requestValidate = function (req) {
+Broker.prototype.requestValidate = function(req) {
   if (!req) {
     return false;
   }
@@ -397,7 +397,7 @@ Broker.prototype.requestValidate = function (req) {
   return true;
 };
 
-Broker.prototype.workerRequire = function (workerId) {
+Broker.prototype.workerRequire = function(workerId) {
   if (this.workers[workerId]) {
     return this.workers[workerId];
   }
@@ -417,7 +417,7 @@ Broker.prototype.workerRequire = function (workerId) {
   return worker;
 };
 
-Broker.prototype.workerDelete = function (workerId, disconnect) {
+Broker.prototype.workerDelete = function(workerId, disconnect) {
   var worker = this.workers[workerId];
 
   if (!worker) {
@@ -477,7 +477,7 @@ Broker.prototype.workerDelete = function (workerId, disconnect) {
   }
 };
 
-Broker.prototype.workersCheck = function () {
+Broker.prototype.workersCheck = function() {
   var self = this;
 
   if (this._wcheck) {
@@ -488,7 +488,7 @@ Broker.prototype.workersCheck = function () {
 
   this._wcheck = (new Date()).getTime();
 
-  _.each(this.workers, function (worker, workerId) {
+  _.each(this.workers, function(worker, workerId) {
     if (!worker) {
       self.workerDelete(workerId, true);
       return;
@@ -508,7 +508,7 @@ Broker.prototype.workersCheck = function () {
   });
 };
 
-Broker.prototype.workerAvailable = function (workerId) {
+Broker.prototype.workerAvailable = function(workerId) {
   if (!workerId) {
     return false;
   }
@@ -529,7 +529,7 @@ Broker.prototype.workerAvailable = function (workerId) {
   return false;
 };
 
-Broker.prototype.serviceRequire = function (srvName) {
+Broker.prototype.serviceRequire = function(srvName) {
   if (this.services[srvName]) {
     return this.services[srvName];
   }
@@ -546,20 +546,20 @@ Broker.prototype.serviceRequire = function (srvName) {
   return service;
 };
 
-Broker.prototype.servicesUpdate = function () {
+Broker.prototype.servicesUpdate = function() {
   var self = this;
 
-  _.each(this.services, function (service, srvName) {
+  _.each(this.services, function(service, srvName) {
     service.aux = [srvName];
   });
 
-  _.each(this.services, function (service, srvName) {
+  _.each(this.services, function(service, srvName) {
     if (srvName.indexOf('@') > 0 && !srvName.match(/@\d+[.]\d+[.]\d+$/)) {
       // find all satisfying services
 
       var prefix = srvName.replace(/@([^@]+)$/, '@');
       var range = srvName.replace(/(^.*@)([^@]+)$/, '$2');
-      var satisfying = _.filter(self.services, function (aService, aSrvName) {
+      var satisfying = _.filter(self.services, function(aService, aSrvName) {
         if (aSrvName == srvName || aSrvName.indexOf(prefix) !== 0 || !aSrvName.match(/@\d+[.]\d+[.]\d+$/)) {
           return false;
         }
@@ -572,11 +572,11 @@ Broker.prototype.servicesUpdate = function () {
     }
   });
 
-  _.each(this.services, function (service, srvName) {
+  _.each(this.services, function(service, srvName) {
     if (!service.workers.length && srvName[srvName.length - 1] !== '*' && srvName.indexOf('@') === -1) {
       // let's find the best matching widlcard services
 
-      var bestMatching = _.reduce(self.services, function (acc, aService, aSrvName) {
+      var bestMatching = _.reduce(self.services, function(acc, aService, aSrvName) {
 
         if (aSrvName == srvName || aSrvName[aSrvName.length - 1] !== '*' || srvName.indexOf(aSrvName.slice(0, -1)) !== 0) {
           return acc;
@@ -591,7 +591,7 @@ Broker.prototype.servicesUpdate = function () {
     }
   });
 
-  _.each(this.services, function (service, srvName) {
+  _.each(this.services, function(service, srvName) {
     service.aux = _.unique(service.aux);
     if (!service.aux.length) {
       delete self.services[srvName];
@@ -599,7 +599,7 @@ Broker.prototype.servicesUpdate = function () {
   });
 };
 
-Broker.prototype.serviceWorkerAdd = function (srvName, workerId) {
+Broker.prototype.serviceWorkerAdd = function(srvName, workerId) {
   var service = this.serviceRequire(srvName);
   var worker = this.workerRequire(workerId);
 
@@ -693,7 +693,7 @@ function _rhandle(srvName, workerIds) {
   return 1;
 }
 
-Broker.prototype.dispatch = function (srvName) {
+Broker.prototype.dispatch = function(srvName) {
   var self = this;
   var service = this.serviceRequire(srvName);
   var qlen = service.q.getLength();
@@ -709,7 +709,7 @@ Broker.prototype.dispatch = function (srvName) {
   }
 
   if (this.conf.dmode === 'load' && workerIds.length > 1) {
-    workerIds.sort(function (a, b) {
+    workerIds.sort(function(a, b) {
       var wa = self.workers[a];
       var wb = self.workers[b];
       var arn = wa.rids.length;
@@ -735,11 +735,11 @@ Broker.prototype.dispatch = function (srvName) {
   }
 };
 
-Broker.prototype.notify = function (channel) {
+Broker.prototype.notify = function(channel) {
   switch (channel) {
     case '$dir':
       this.pub.send('$dir ' + JSON.stringify(
-        _.reduce(this.services, function (acc, service, srvName) {
+        _.reduce(this.services, function(acc, service, srvName) {
           acc[srvName] = service.workers;
           return acc;
         }, {})

--- a/lib/Broker.js
+++ b/lib/Broker.js
@@ -209,11 +209,11 @@ Broker.prototype.onClient = function(msg) {
   if (type == MDP.W_REQUEST) {
     var srvName = msg[3] || 'UNK';
     var rid = msg[4];
-    debug("B: REQUEST from clientId: %s, service: %s", clientId, srvName);
+    debug('B: REQUEST from clientId: %s, service: %s', clientId, srvName);
 
     var opts = msg[6];
 
-    try { opts = JSON.parse(opts); } catch(e) {};
+    try { opts = JSON.parse(opts); } catch(e) {}
     if (!_.isObject(opts)) {
       opts = {};
     }
@@ -250,7 +250,7 @@ Broker.prototype.onWorker = function(msg) {
   var type = msg[2];
 
   var wready = (workerId in this.workers);
-  var worker = this.workerRequire(workerId)
+  var worker = this.workerRequire(workerId);
 
   if (type == MDP.W_READY) {
     var srvName = msg[3];
@@ -281,14 +281,14 @@ Broker.prototype.onWorker = function(msg) {
     var rid = msg[5];
 
     if (_.indexOf(worker.rids, rid) === -1) {
-      debug("B: FATAL from worker '%s' (%s), rid not found mismatch '%s'", workerId, worker.service, rid);
+      debug('B: FATAL from worker \'%s\' (%s), rid not found mismatch \'%s\'', workerId, worker.service, rid);
       this.workerDelete(workerId, true);
       return;
     }
 
     var req = this.rmap[rid];
     if (!req) {
-      debug("B: FATAL from worker '%s' (%s), req not found", workerId, worker.service, rid);
+      debug('B: FATAL from worker \'%s\' (%s), req not found', workerId, worker.service, rid);
       this.workerDelete(workerId, true);
       return;
     }
@@ -296,7 +296,7 @@ Broker.prototype.onWorker = function(msg) {
     var service = this.serviceRequire(req.service);
 
     if (type == MDP.W_REPLY_REJECT) {
-      debug("B: REJECT from worker '%s' (%s) for req '%s'", workerId, worker.service, rid);
+      debug('B: REJECT from worker \'%s\' (%s) for req \'%s\'', workerId, worker.service, rid);
 
       req.rejects.push(workerId);
       delete req.workerId;
@@ -306,10 +306,10 @@ Broker.prototype.onWorker = function(msg) {
       this.dispatch(req.service);
 
     } else if (type == MDP.W_REPLY || type == MDP.W_REPLY_PARTIAL) {
-      debug("B: REPLY from worker '%s' (%s)", workerId, worker.service);
+      debug('B: REPLY from worker \'%s\' (%s)', workerId, worker.service);
 
       var opts = msg[8];
-      try { opts = JSON.parse(opts); } catch(e) {};
+      try { opts = JSON.parse(opts); } catch(e) {}
       if (!_.isObject(opts)) {
         opts = {};
       }
@@ -331,7 +331,7 @@ Broker.prototype.onWorker = function(msg) {
       opts = JSON.parse(opts); 
     } catch(e) {
       opts = {};
-    };
+    }
     
     _.each(['concurrency'], function(fld) {
       if (!_.isUndefined(opts[fld])) {
@@ -499,9 +499,9 @@ Broker.prototype.workersCheck = function() {
       return;
     }
 
-      if(worker.liveness < HEARTBEAT_LIVENESS){ 
-        self.send([workerId, MDP.WORKER, MDP.W_HEARTBEAT]);
-      }
+    if(worker.liveness < HEARTBEAT_LIVENESS){ 
+      self.send([workerId, MDP.WORKER, MDP.W_HEARTBEAT]);
+    }
   });
 };
 
@@ -577,14 +577,14 @@ Broker.prototype.servicesUpdate = function() {
 
         if (aSrvName == srvName || aSrvName[aSrvName.length - 1] !== '*' || srvName.indexOf(aSrvName.slice(0, -1)) !== 0) {
           return acc;
-        };
+        }
 
         return aSrvName.length > acc.length ? aSrvName : acc;
       }, '');
 
       if (bestMatching) {
         service.aux.push(bestMatching);
-      };
+      }
     }
   });
 
@@ -688,7 +688,7 @@ function _rhandle(srvName, workerIds) {
   this.send(obj);
   
   return 1;
-};
+}
 
 Broker.prototype.dispatch = function(srvName) {
   var self = this;
@@ -734,8 +734,8 @@ Broker.prototype.dispatch = function(srvName) {
 
 Broker.prototype.notify = function(channel) {
   switch (channel) {
-    case '$dir':
-      this.pub.send('$dir ' + JSON.stringify(
+  case '$dir':
+    this.pub.send('$dir ' + JSON.stringify(
         _.reduce(this.services, function(acc, service, srvName) {
           acc[srvName] = service.workers;
           return acc; 

--- a/lib/BrokerController.js
+++ b/lib/BrokerController.js
@@ -5,7 +5,7 @@ function BrokerController() {
   this.__srq = {};
 
   this.init();
-};
+}
 
 BrokerController.prototype.init = function() {};
 

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -32,7 +32,7 @@ function Client(broker, conf) {
   if (this.conf.autostart) {
     this.start();
   }
-};
+}
 util.inherits(Client, events.EventEmitter);
 
 Client.prototype.onConnect = function() {
@@ -217,7 +217,7 @@ function _request(serviceName, data, _opts) {
   var opts = _.isObject(_opts) ? _opts : {};
 
   _.each(['timeout', 'retry'], function(fld) {
-    opts[fld] = opts[fld] !== undefined ? opts[fld] : self.conf[fld]
+    opts[fld] = opts[fld] !== undefined ? opts[fld] : self.conf[fld];
   });
 
   var req = this.reqs[rid] = {
@@ -251,7 +251,7 @@ function _request(serviceName, data, _opts) {
   ]);
 
   return req;
-};
+}
 
 Client.prototype.requestStream = function(serviceName, data, opts) {
   return this.request(serviceName, data, opts);

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -209,8 +209,6 @@ Client.prototype.emitErr = function(msg) {
 
 function noop() {}
 
-var rcnt = 0;
-
 function _request(serviceName, data, _opts) {
   var self = this;
   var rid = uuid.v4();

--- a/lib/Worker.js
+++ b/lib/Worker.js
@@ -1,5 +1,5 @@
 var zmq = require('zmq');
-var Writable = require('readable-stream').Writable
+var Writable = require('readable-stream').Writable;
 var debug = require('debug')('pigato:Worker');
 var uuid = require('node-uuid');
 var util = require('util');
@@ -200,8 +200,8 @@ Worker.prototype.onRequest = function(clientId, service, rid, data, opts) {
     opts: {} 
   };
 
-  try { req.data = JSON.parse(data); } catch(e) {};
-  try { req.opts = JSON.parse(opts); } catch(e) {};
+  try { req.data = JSON.parse(data); } catch(e) {}
+  try { req.opts = JSON.parse(opts); } catch(e) {}
 
   this.reqs[rid] = req;
 

--- a/lib/Worker.js
+++ b/lib/Worker.js
@@ -55,6 +55,9 @@ Worker.prototype.start = function() {
   this._mcnt = 0;
 
   this.socket = zmq.socket('dealer');
+
+  this.conf.name = 'W' + uuid.v4();
+
   this.socket.identity = new Buffer(this.conf.name);
   this.socket.setsockopt('linger', 1);
 
@@ -108,7 +111,7 @@ Worker.prototype.stop = function() {
     
     var socket = this.socket;
     delete this.socket;
-    
+
     setImmediate(function() {
       if (socket._zmq.state != zmq.STATE_CLOSED) {
         socket.close();

--- a/lib/Worker.js
+++ b/lib/Worker.js
@@ -56,8 +56,6 @@ Worker.prototype.start = function() {
 
   this.socket = zmq.socket('dealer');
 
-  this.conf.name = 'W' + uuid.v4();
-
   this.socket.identity = new Buffer(this.conf.name);
   this.socket.setsockopt('linger', 1);
 

--- a/lib/Worker.js
+++ b/lib/Worker.js
@@ -200,8 +200,12 @@ Worker.prototype.onRequest = function(clientId, service, rid, data, opts) {
     opts: {} 
   };
 
-  try { req.data = JSON.parse(data); } catch(e) {}
-  try { req.opts = JSON.parse(opts); } catch(e) {}
+  try { req.data = JSON.parse(data); } catch(e) {
+    // Ignore
+  }
+  try { req.opts = JSON.parse(opts); } catch(e) {
+    // Ignore
+  }
 
   this.reqs[rid] = req;
 

--- a/lib/q.js
+++ b/lib/q.js
@@ -15,15 +15,15 @@ function Queue(){
 
   this.getLength = function(){
     return (queue.length - offset);
-  }
+  };
 
   this.isEmpty = function(){
     return (queue.length == 0);
-  }
+  };
 
   this.enqueue = function(item){
     queue.push(item);
-  }
+  };
 
   this.dequeue = function(){
     if (queue.length == 0) return undefined;
@@ -37,11 +37,11 @@ function Queue(){
 
     return item;
 
-  }
+  };
 
   this.peek = function(){
     return (queue.length > 0 ? queue[offset] : undefined);
-  }
+  };
 }
 
 module.exports = Queue;

--- a/package.json
+++ b/package.json
@@ -48,5 +48,8 @@
   "bugs": {
     "url": "https://github.com/prdn/pigato/issues"
   },
-  "homepage": "https://github.com/prdn/pigato"
+  "homepage": "https://github.com/prdn/pigato",
+  "optionalDependencies": {
+    "eslint": "~1.6.0"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "mocha": "~2.2.5"
   },
   "scripts": {
-    "test": "make test"
+    "test": "make test",
+    "lint": "eslint --config .eslintrc index.js lib/ test/"
   },
   "license": "MIT",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "scripts": {
     "test": "make test",
-    "lint": "eslint --config .eslintrc index.js lib/ test/"
+    "lint": "eslint --config .eslintrc --fix index.js lib/ test/"
   },
   "license": "MIT",
   "repository": {

--- a/test/client.js
+++ b/test/client.js
@@ -13,27 +13,27 @@ var bhost;
 
 var client, clientOpts;
 
-describe('Client', function () {
+describe('Client', function() {
   var mockBroker;
 
-  beforeEach(function () {
+  beforeEach(function() {
     bhost = location + uuid.v4();
     client = new PIGATO.Client(bhost, clientOpts);
     mockBroker = zmq.socket('router');
     mockBroker.bindSync(bhost);
   });
 
-  afterEach(function () {
+  afterEach(function() {
     client.removeAllListeners();
     client.stop();
     mockBroker.unbind(bhost);
   });
 
-  it('connect to a zmq endpoint and call callback once heartbeat made round trip', function (done) {
+  it('connect to a zmq endpoint and call callback once heartbeat made round trip', function(done) {
 
     var called = false;
 
-    mockBroker.on('message', function (a, b, c) {
+    mockBroker.on('message', function(a, b, c) {
       assert.equal(client.conf.name, a.toString());
       assert.equal(MDP.CLIENT, b.toString());
       assert.equal(MDP.W_HEARTBEAT, c.toString());
@@ -42,7 +42,7 @@ describe('Client', function () {
       called = true;
     });
 
-    client.conf.onConnect = function () {
+    client.conf.onConnect = function() {
       assert.equal(true, called);
       delete client.conf.onConnect;
       done();
@@ -51,11 +51,11 @@ describe('Client', function () {
     client.start();
   });
 
-  it('connect to a zmq endpoint and emit connect once heartbeat made round trip', function (done) {
+  it('connect to a zmq endpoint and emit connect once heartbeat made round trip', function(done) {
 
     var called = false;
 
-    mockBroker.on('message', function (a, b, c) {
+    mockBroker.on('message', function(a, b, c) {
       assert.equal(client.conf.name, a.toString());
       assert.equal(MDP.CLIENT, b.toString());
       assert.equal(MDP.W_HEARTBEAT, c.toString());
@@ -64,7 +64,7 @@ describe('Client', function () {
       called = true;
     });
 
-    client.on('connect', function () {
+    client.on('connect', function() {
       assert.equal(true, called);
       done();
     });
@@ -72,25 +72,25 @@ describe('Client', function () {
   });
 
 
-  it('doesn\'t call callback if no heartbeat response', function (done) {
+  it('doesn\'t call callback if no heartbeat response', function(done) {
 
     var called = false;
     var cbCalled = false;
 
-    mockBroker.on('message', function (a, b, c) {
+    mockBroker.on('message', function(a, b, c) {
       assert.equal(client.conf.name, a.toString());
       assert.equal(MDP.CLIENT, b.toString());
       assert.equal(MDP.W_HEARTBEAT, c.toString());
       called = true;
     });
 
-    client.on('connect', function () {
+    client.on('connect', function() {
       cbCalled = true;
     });
 
     client.start();
 
-    setTimeout(function () {
+    setTimeout(function() {
       assert.equal(true, called);
       assert.equal(false, cbCalled);
       done();
@@ -98,12 +98,12 @@ describe('Client', function () {
   });
 
 
-  it('emit an error if answer with bad header', function (done) {
+  it('emit an error if answer with bad header', function(done) {
 
     var called = false;
     var cbCalled = false;
 
-    mockBroker.on('message', function (a, b, c) {
+    mockBroker.on('message', function(a, b, c) {
       assert.equal(client.conf.name, a.toString());
       assert.equal(MDP.CLIENT, b.toString());
       assert.equal(MDP.W_HEARTBEAT, c.toString());
@@ -112,14 +112,14 @@ describe('Client', function () {
       called = true;
     });
 
-    client.on('error', function (err) {
+    client.on('error', function(err) {
       assert.equal('ERR_MSG_HEADER', err);
       assert.equal(true, called);
       assert.equal(false, cbCalled);
       done();
     });
 
-    client.on('connect', function () {
+    client.on('connect', function() {
       cbCalled = true;
     });
 
@@ -127,12 +127,12 @@ describe('Client', function () {
   });
 
 
-  it('doesn\'t call callback if answer with bad id', function (done) {
+  it('doesn\'t call callback if answer with bad id', function(done) {
 
     var called = false;
     var cbCalled = false;
 
-    mockBroker.on('message', function (a, b, c) {
+    mockBroker.on('message', function(a, b, c) {
       assert.equal(client.conf.name, a.toString());
       assert.equal(MDP.CLIENT, b.toString());
       assert.equal(MDP.W_HEARTBEAT, c.toString());
@@ -140,13 +140,13 @@ describe('Client', function () {
       called = true;
     });
 
-    client.on('connect', function () {
+    client.on('connect', function() {
       cbCalled = true;
     });
 
     client.start();
 
-    setTimeout(function () {
+    setTimeout(function() {
       assert.equal(true, called);
       assert.equal(false, cbCalled);
       done();
@@ -154,10 +154,10 @@ describe('Client', function () {
   });
 
 
-  it('can do callback request with no partial', function (done) {
+  it('can do callback request with no partial', function(done) {
     var toAnswer = uuid.v4();
 
-    mockBroker.on('message', function (id, clazz, type, topic, rid) {
+    mockBroker.on('message', function(id, clazz, type, topic, rid) {
       if (type.toString() == MDP.W_HEARTBEAT) {
         mockBroker.send([id, clazz, MDP.W_HEARTBEAT]);
         return;
@@ -171,10 +171,10 @@ describe('Client', function () {
 
     var partial = false;
 
-    client.on('connect', function () {
-      client.request('foo', 'bar', function () {
+    client.on('connect', function() {
+      client.request('foo', 'bar', function() {
         partial = true;
-      }, function (err, data) {
+      }, function(err, data) {
         assert.equal(false, partial);
         assert.equal(err, 0);
         assert.equal(data, toAnswer);
@@ -184,10 +184,10 @@ describe('Client', function () {
     client.start();
   });
 
-  it('can do stream request with no partial', function (done) {
+  it('can do stream request with no partial', function(done) {
     var toAnswer = uuid.v4();
 
-    mockBroker.on('message', function (id, clazz, type, topic, rid) {
+    mockBroker.on('message', function(id, clazz, type, topic, rid) {
       if (type.toString() == MDP.W_HEARTBEAT) {
         mockBroker.send([id, clazz, MDP.W_HEARTBEAT]);
         return;
@@ -198,8 +198,8 @@ describe('Client', function () {
       }
     });
 
-    client.on('connect', function () {
-      client.request('foo', 'bar').on('data', function (data) {
+    client.on('connect', function() {
+      client.request('foo', 'bar').on('data', function(data) {
         assert.equal(data, toAnswer);
       }).on('end', done);
     });
@@ -207,11 +207,11 @@ describe('Client', function () {
   });
 
 
-  it('can do stream request with partial', function (done) {
+  it('can do stream request with partial', function(done) {
 
     var reponses = ['one', 'two', 'three'];
 
-    mockBroker.on('message', function (id, clazz, type, topic, rid) {
+    mockBroker.on('message', function(id, clazz, type, topic, rid) {
       if (type.toString() == MDP.W_HEARTBEAT) {
         mockBroker.send([id, clazz, MDP.W_HEARTBEAT]);
         return;
@@ -226,12 +226,12 @@ describe('Client', function () {
 
     var index = 0;
 
-    client.on('connect', function () {
-      client.request('foo', 'bar').on('data', function (data) {
+    client.on('connect', function() {
+      client.request('foo', 'bar').on('data', function(data) {
         assert.equal(data, reponses[index]);
         index++;
 
-      }).on('end', function () {
+      }).on('end', function() {
         assert.equal(3, index);
         done();
       });
@@ -240,11 +240,11 @@ describe('Client', function () {
     client.start();
   });
 
-  it('can do callback request with partial', function (done) {
+  it('can do callback request with partial', function(done) {
 
     var reponses = ['one', 'two', 'three'];
 
-    mockBroker.on('message', function (id, clazz, type, topic, rid) {
+    mockBroker.on('message', function(id, clazz, type, topic, rid) {
       if (type.toString() == MDP.W_HEARTBEAT) {
         mockBroker.send([id, clazz, MDP.W_HEARTBEAT]);
         return;
@@ -258,11 +258,11 @@ describe('Client', function () {
     });
 
     var index = 0;
-    client.on('connect', function () {
-      client.request('foo', 'bar', function (err, data) {
+    client.on('connect', function() {
+      client.request('foo', 'bar', function(err, data) {
         assert.equal(data, reponses[index]);
         index++;
-      }, function (err, data) {
+      }, function(err, data) {
         assert.equal(2, index);
         assert.equal(data, reponses[index]);
         done();
@@ -272,22 +272,22 @@ describe('Client', function () {
   });
 
 
-  it('emit an error if ERR_MSG_LENGTH we send a message to short', function (done) {
+  it('emit an error if ERR_MSG_LENGTH we send a message to short', function(done) {
 
-    client.on('error', function (err) {
+    client.on('error', function(err) {
       assert.ok(err);
       assert.equal(err, 'ERR_MSG_LENGTH');
       done();
     });
 
 
-    mockBroker.on('message', function (id, clazz, type) {
+    mockBroker.on('message', function(id, clazz, type) {
       if (type.toString() == MDP.W_HEARTBEAT) {
         mockBroker.send([id, clazz, MDP.W_HEARTBEAT]);
         return;
       }
     });
-    client.on('connect', function () {
+    client.on('connect', function() {
       mockBroker.send([client.conf.name, MDP.CLIENT, MDP.W_REPLY]);
 
     });
@@ -295,9 +295,9 @@ describe('Client', function () {
   });
 
 
-  it('emit an ERR_REQ_INVALID error if we send a reply to an invalid request', function (done) {
+  it('emit an ERR_REQ_INVALID error if we send a reply to an invalid request', function(done) {
 
-    client.on('error', function (err) {
+    client.on('error', function(err) {
       assert.ok(err);
       assert.equal(err, 'ERR_REQ_INVALID');
       done();
@@ -305,13 +305,13 @@ describe('Client', function () {
     });
 
 
-    mockBroker.on('message', function (id, clazz, type) {
+    mockBroker.on('message', function(id, clazz, type) {
       if (type.toString() == MDP.W_HEARTBEAT) {
         mockBroker.send([id, clazz, MDP.W_HEARTBEAT]);
         return;
       }
     });
-    client.on('connect', function () {
+    client.on('connect', function() {
       mockBroker.send([client.conf.name, MDP.CLIENT, MDP.W_REPLY, '', 'MYUNKNOWREQUEST', null, JSON.stringify('bar')]);
 
     });
@@ -319,11 +319,11 @@ describe('Client', function () {
   });
 
 
-  it('emit an error if answer with bad type', function (done) {
+  it('emit an error if answer with bad type', function(done) {
 
     var called = false;
 
-    mockBroker.on('message', function (id, clazz, type, topic, rid) {
+    mockBroker.on('message', function(id, clazz, type, topic, rid) {
       if (type.toString() == MDP.W_HEARTBEAT) {
         mockBroker.send([id, clazz, MDP.W_HEARTBEAT]);
         return;
@@ -335,17 +335,17 @@ describe('Client', function () {
       }
     });
 
-    client.on('error', function (err) {
+    client.on('error', function(err) {
       assert.ok(err);
       assert.equal(err, 'ERR_MSG_TYPE');
       assert.equal(true, called);
       done();
     });
 
-    client.on('connect', function () {
-      client.request('foo', 'bar', function () {
+    client.on('connect', function() {
+      client.request('foo', 'bar', function() {
         assert.ok(false);
-      }, function () {
+      }, function() {
         assert.ok(false);
       });
     });
@@ -353,27 +353,27 @@ describe('Client', function () {
   });
 
 
-  describe('when timeout exceeded with heartbeat short ', function () {
+  describe('when timeout exceeded with heartbeat short ', function() {
 
-    before(function () {
+    before(function() {
       clientOpts = {
         heartbeat: 20
       };
     });
 
-    it('emit an error when timeout exceeded', function (done) {
+    it('emit an error when timeout exceeded', function(done) {
 
-      mockBroker.on('message', function (id, clazz, type) {
+      mockBroker.on('message', function(id, clazz, type) {
         if (type.toString() == MDP.W_HEARTBEAT) {
           mockBroker.send([id, clazz, MDP.W_HEARTBEAT]);
           return;
         }
       });
 
-      client.on('connect', function () {
-        client.request('foo', 'bar', function () {
+      client.on('connect', function() {
+        client.request('foo', 'bar', function() {
           assert.ok(false);
-        }, function (err, data) {
+        }, function(err, data) {
           assert.ok(err);
           assert.equal(data, undefined);
           assert.equal('C_TIMEOUT', err);
@@ -385,36 +385,36 @@ describe('Client', function () {
       client.start();
     });
 
-    after(function () {
+    after(function() {
       clientOpts = undefined;
     });
   });
 
 
-  describe('when timeout exceeded with heartbeat long ', function () {
+  describe('when timeout exceeded with heartbeat long ', function() {
 
-    before(function () {
+    before(function() {
       clientOpts = {
         heartbeat: 50
       };
     });
 
-    it('wait for the heartbeat to expire before the error is returned', function (done) {
+    it('wait for the heartbeat to expire before the error is returned', function(done) {
 
       var cbCalled = false;
 
-      mockBroker.on('message', function (id, clazz, type) {
+      mockBroker.on('message', function(id, clazz, type) {
         if (type.toString() == MDP.W_HEARTBEAT) {
           mockBroker.send([id, clazz, MDP.W_HEARTBEAT]);
           return;
         }
       });
 
-      client.on('connect', function () {
+      client.on('connect', function() {
 
-        client.request('foo', 'bar', function () {
+        client.request('foo', 'bar', function() {
           assert.ok(false);
-        }, function (err, data) {
+        }, function(err, data) {
           cbCalled = true;
           assert.ok(err);
           assert.equal(data, undefined);
@@ -426,35 +426,35 @@ describe('Client', function () {
 
       client.start();
 
-      setTimeout(function () {
+      setTimeout(function() {
         assert.equal(false, cbCalled);
       }, 30);
 
-      setTimeout(function () {
+      setTimeout(function() {
         assert.equal(true, cbCalled);
         done();
       }, 60);
     });
 
-    after(function () {
+    after(function() {
       clientOpts = undefined;
     });
   });
 
 
-  describe('when heartbeat is setted', function () {
+  describe('when heartbeat is setted', function() {
 
-    before(function () {
+    before(function() {
       clientOpts = {
         heartbeat: 25
       };
     });
 
-    it('send heartbeat regularly', function (done) {
+    it('send heartbeat regularly', function(done) {
 
       var heartbeatCount = 0;
 
-      mockBroker.on('message', function (id, clazz, type) {
+      mockBroker.on('message', function(id, clazz, type) {
         if (type.toString() == MDP.W_HEARTBEAT) {
           mockBroker.send([id, clazz, MDP.W_HEARTBEAT]);
           heartbeatCount++;
@@ -462,10 +462,10 @@ describe('Client', function () {
         }
       });
 
-      client.on('connect', function () {
+      client.on('connect', function() {
         assert.equal(1, heartbeatCount);
 
-        setTimeout(function () {
+        setTimeout(function() {
           assert.equal(3, heartbeatCount);
           done();
         }, 60);
@@ -474,18 +474,18 @@ describe('Client', function () {
       client.start();
     });
 
-    after(function () {
+    after(function() {
       clientOpts = undefined;
     });
   });
 
 
-  it('can send heartbeat from a request, and it will send the good requestId', function (done) {
+  it('can send heartbeat from a request, and it will send the good requestId', function(done) {
 
     var heartbeatCount = 0;
     var requestId;
 
-    mockBroker.on('message', function (id, clazz, type, topic, rid) {
+    mockBroker.on('message', function(id, clazz, type, topic, rid) {
       if (type.toString() == MDP.W_HEARTBEAT && topic == undefined) {
         mockBroker.send([id, clazz, MDP.W_HEARTBEAT]);
         return;
@@ -510,7 +510,7 @@ describe('Client', function () {
 
     });
 
-    client.on('connect', function () {
+    client.on('connect', function() {
       var req = client.request('foo', 'bar');
       req.heartbeat();
     });
@@ -519,12 +519,12 @@ describe('Client', function () {
   });
 
 
-  it('can send manual heartbeat for an unknown request', function (done) {
+  it('can send manual heartbeat for an unknown request', function(done) {
 
     var heartbeatCount = 0;
     var heartbeatContent = ['ONE', 'TWO', 'THREE', 'THREE'];
 
-    mockBroker.on('message', function (id, clazz, type, rid) {
+    mockBroker.on('message', function(id, clazz, type, rid) {
       if (type.toString() == MDP.W_HEARTBEAT && rid == undefined) {
         mockBroker.send([id, clazz, MDP.W_HEARTBEAT]);
         return;
@@ -544,7 +544,7 @@ describe('Client', function () {
 
     });
 
-    client.on('connect', function () {
+    client.on('connect', function() {
       client.heartbeat(heartbeatContent[0]);
       client.heartbeat(heartbeatContent[1]);
       client.heartbeat(heartbeatContent[2]);

--- a/test/client.js
+++ b/test/client.js
@@ -4,8 +4,8 @@ var MDP = require('../lib/mdp');
 
 var PIGATO = require('../');
 
-var chai = require('chai'),
-  assert = chai.assert;
+var chai = require('chai');
+var assert = chai.assert;
 var uuid = require('node-uuid');
 
 var location = 'inproc://#';
@@ -13,27 +13,27 @@ var bhost;
 
 var client, clientOpts;
 
-describe('Client', function() {
+describe('Client', function () {
   var mockBroker;
 
-  beforeEach(function() {
+  beforeEach(function () {
     bhost = location + uuid.v4();
     client = new PIGATO.Client(bhost, clientOpts);
     mockBroker = zmq.socket('router');
     mockBroker.bindSync(bhost);
   });
 
-  afterEach(function() {
+  afterEach(function () {
     client.removeAllListeners();
     client.stop();
     mockBroker.unbind(bhost);
   });
 
-  it('connect to a zmq endpoint and call callback once heartbeat made round trip', function(done) {
+  it('connect to a zmq endpoint and call callback once heartbeat made round trip', function (done) {
 
     var called = false;
 
-    mockBroker.on('message', function(a, b, c) {
+    mockBroker.on('message', function (a, b, c) {
       assert.equal(client.conf.name, a.toString());
       assert.equal(MDP.CLIENT, b.toString());
       assert.equal(MDP.W_HEARTBEAT, c.toString());
@@ -42,20 +42,20 @@ describe('Client', function() {
       called = true;
     });
 
-    client.conf.onConnect = function() {
+    client.conf.onConnect = function () {
       assert.equal(true, called);
       delete client.conf.onConnect;
       done();
     };
-    
+
     client.start();
   });
 
-  it('connect to a zmq endpoint and emit connect once heartbeat made round trip', function(done) {
+  it('connect to a zmq endpoint and emit connect once heartbeat made round trip', function (done) {
 
     var called = false;
 
-    mockBroker.on('message', function(a, b, c) {
+    mockBroker.on('message', function (a, b, c) {
       assert.equal(client.conf.name, a.toString());
       assert.equal(MDP.CLIENT, b.toString());
       assert.equal(MDP.W_HEARTBEAT, c.toString());
@@ -64,7 +64,7 @@ describe('Client', function() {
       called = true;
     });
 
-    client.on('connect', function() {
+    client.on('connect', function () {
       assert.equal(true, called);
       done();
     });
@@ -72,39 +72,38 @@ describe('Client', function() {
   });
 
 
-  it('doesn\'t call callback if no heartbeat response', function(done) {
+  it('doesn\'t call callback if no heartbeat response', function (done) {
 
     var called = false;
     var cbCalled = false;
 
-    mockBroker.on('message', function(a, b, c) {
+    mockBroker.on('message', function (a, b, c) {
       assert.equal(client.conf.name, a.toString());
       assert.equal(MDP.CLIENT, b.toString());
       assert.equal(MDP.W_HEARTBEAT, c.toString());
       called = true;
     });
 
-    client.on('connect', function() {
+    client.on('connect', function () {
       cbCalled = true;
     });
 
     client.start();
 
-    setTimeout(function() {
+    setTimeout(function () {
       assert.equal(true, called);
       assert.equal(false, cbCalled);
       done();
     }, 20);
   });
 
-  
-  
-  it('emit an error if answer with bad header', function(done) {
+
+  it('emit an error if answer with bad header', function (done) {
 
     var called = false;
     var cbCalled = false;
 
-    mockBroker.on('message', function(a, b, c) {
+    mockBroker.on('message', function (a, b, c) {
       assert.equal(client.conf.name, a.toString());
       assert.equal(MDP.CLIENT, b.toString());
       assert.equal(MDP.W_HEARTBEAT, c.toString());
@@ -113,41 +112,41 @@ describe('Client', function() {
       called = true;
     });
 
-    client.on('error', function(err) {
+    client.on('error', function (err) {
       assert.equal('ERR_MSG_HEADER', err);
       assert.equal(true, called);
       assert.equal(false, cbCalled);
       done();
     });
 
-    client.on('connect', function() {
+    client.on('connect', function () {
       cbCalled = true;
     });
 
     client.start();
   });
 
-    
-  it('doesn\'t call callback if answer with bad id', function(done) {
+
+  it('doesn\'t call callback if answer with bad id', function (done) {
 
     var called = false;
     var cbCalled = false;
 
-    mockBroker.on('message', function(a, b, c) {
+    mockBroker.on('message', function (a, b, c) {
       assert.equal(client.conf.name, a.toString());
       assert.equal(MDP.CLIENT, b.toString());
       assert.equal(MDP.W_HEARTBEAT, c.toString());
-      mockBroker.send([a + '' +uuid.v4(), b, MDP.W_HEARTBEAT]);
+      mockBroker.send([a + '' + uuid.v4(), b, MDP.W_HEARTBEAT]);
       called = true;
     });
 
-    client.on('connect', function() {
+    client.on('connect', function () {
       cbCalled = true;
     });
 
     client.start();
 
-    setTimeout(function() {
+    setTimeout(function () {
       assert.equal(true, called);
       assert.equal(false, cbCalled);
       done();
@@ -155,14 +154,10 @@ describe('Client', function() {
   });
 
 
-  it('can do callback request with no partial', function(done) {
-
-    var called = false;
-    var cbCalled = false;
-
+  it('can do callback request with no partial', function (done) {
     var toAnswer = uuid.v4();
 
-    mockBroker.on('message', function(id, clazz, type, topic, rid, data, opts) {
+    mockBroker.on('message', function (id, clazz, type, topic, rid) {
       if (type.toString() == MDP.W_HEARTBEAT) {
         mockBroker.send([id, clazz, MDP.W_HEARTBEAT]);
         return;
@@ -176,10 +171,10 @@ describe('Client', function() {
 
     var partial = false;
 
-    client.on('connect', function() {
-      client.request('foo', 'bar', function() {
-         partial = true;
-       }, function(err, data) {
+    client.on('connect', function () {
+      client.request('foo', 'bar', function () {
+        partial = true;
+      }, function (err, data) {
         assert.equal(false, partial);
         assert.equal(err, 0);
         assert.equal(data, toAnswer);
@@ -189,14 +184,10 @@ describe('Client', function() {
     client.start();
   });
 
-  it('can do stream request with no partial', function(done) {
-
-    var called = false;
-    var cbCalled = false;
-
+  it('can do stream request with no partial', function (done) {
     var toAnswer = uuid.v4();
 
-    mockBroker.on('message', function(id, clazz, type, topic, rid, data, opts) {
+    mockBroker.on('message', function (id, clazz, type, topic, rid) {
       if (type.toString() == MDP.W_HEARTBEAT) {
         mockBroker.send([id, clazz, MDP.W_HEARTBEAT]);
         return;
@@ -207,27 +198,20 @@ describe('Client', function() {
       }
     });
 
-    var partial = false;
-    client.on('connect', function() {
-      client.request('foo', 'bar').on('data', function(data) {
+    client.on('connect', function () {
+      client.request('foo', 'bar').on('data', function (data) {
         assert.equal(data, toAnswer);
-      }).on('end', function(err, data) {
-        done();
-      });
+      }).on('end', done);
     });
     client.start();
   });
 
 
-
-  it('can do stream request with partial', function(done) {
-
-    var called = false;
-    var cbCalled = false;
+  it('can do stream request with partial', function (done) {
 
     var reponses = ['one', 'two', 'three'];
 
-    mockBroker.on('message', function(id, clazz, type, topic, rid, data, opts) {
+    mockBroker.on('message', function (id, clazz, type, topic, rid) {
       if (type.toString() == MDP.W_HEARTBEAT) {
         mockBroker.send([id, clazz, MDP.W_HEARTBEAT]);
         return;
@@ -240,16 +224,14 @@ describe('Client', function() {
       }
     });
 
-
-    var partial = false;
     var index = 0;
 
-    client.on('connect', function() {
-      client.request('foo', 'bar').on('data', function(data) {
+    client.on('connect', function () {
+      client.request('foo', 'bar').on('data', function (data) {
         assert.equal(data, reponses[index]);
         index++;
 
-      }).on('end', function(err, data) {
+      }).on('end', function () {
         assert.equal(3, index);
         done();
       });
@@ -258,14 +240,11 @@ describe('Client', function() {
     client.start();
   });
 
-  it('can do callback request with partial', function(done) {
-
-    var called = false;
-    var cbCalled = false;
+  it('can do callback request with partial', function (done) {
 
     var reponses = ['one', 'two', 'three'];
 
-    mockBroker.on('message', function(id, clazz, type, topic, rid, data, opts) {
+    mockBroker.on('message', function (id, clazz, type, topic, rid) {
       if (type.toString() == MDP.W_HEARTBEAT) {
         mockBroker.send([id, clazz, MDP.W_HEARTBEAT]);
         return;
@@ -278,13 +257,12 @@ describe('Client', function() {
       }
     });
 
-    var partial = false;
     var index = 0;
-    client.on('connect', function() {
-      client.request('foo', 'bar', function(err, data) {
+    client.on('connect', function () {
+      client.request('foo', 'bar', function (err, data) {
         assert.equal(data, reponses[index]);
         index++;
-      }, function(err, data) {
+      }, function (err, data) {
         assert.equal(2, index);
         assert.equal(data, reponses[index]);
         done();
@@ -294,46 +272,46 @@ describe('Client', function() {
   });
 
 
-  it('emit an error if ERR_MSG_LENGTH we send a message to short', function(done) {
+  it('emit an error if ERR_MSG_LENGTH we send a message to short', function (done) {
 
-    client.on('error', function(err) {
+    client.on('error', function (err) {
       assert.ok(err);
       assert.equal(err, 'ERR_MSG_LENGTH');
       done();
     });
 
 
-    mockBroker.on('message', function(id, clazz, type, topic, rid, data, opts) {
+    mockBroker.on('message', function (id, clazz, type) {
       if (type.toString() == MDP.W_HEARTBEAT) {
         mockBroker.send([id, clazz, MDP.W_HEARTBEAT]);
         return;
       }
     });
-    client.on('connect', function() {
-      mockBroker.send([client.conf.name, MDP.CLIENT, MDP.W_REPLY ]);
+    client.on('connect', function () {
+      mockBroker.send([client.conf.name, MDP.CLIENT, MDP.W_REPLY]);
 
     });
     client.start();
   });
 
 
-  it('emit an ERR_REQ_INVALID error if we send a reply to an invalid request', function(done) {
+  it('emit an ERR_REQ_INVALID error if we send a reply to an invalid request', function (done) {
 
-    client.on('error', function(err) {
+    client.on('error', function (err) {
       assert.ok(err);
       assert.equal(err, 'ERR_REQ_INVALID');
       done();
-    
+
     });
 
 
-    mockBroker.on('message', function(id, clazz, type, topic, rid, data, opts) {
+    mockBroker.on('message', function (id, clazz, type) {
       if (type.toString() == MDP.W_HEARTBEAT) {
         mockBroker.send([id, clazz, MDP.W_HEARTBEAT]);
         return;
       }
     });
-    client.on('connect', function() {
+    client.on('connect', function () {
       mockBroker.send([client.conf.name, MDP.CLIENT, MDP.W_REPLY, '', 'MYUNKNOWREQUEST', null, JSON.stringify('bar')]);
 
     });
@@ -341,12 +319,11 @@ describe('Client', function() {
   });
 
 
-  it('emit an error if answer with bad type', function(done) {
+  it('emit an error if answer with bad type', function (done) {
 
     var called = false;
-    var cbCalled = false;
 
-    mockBroker.on('message', function(id, clazz, type, topic, rid) {
+    mockBroker.on('message', function (id, clazz, type, topic, rid) {
       if (type.toString() == MDP.W_HEARTBEAT) {
         mockBroker.send([id, clazz, MDP.W_HEARTBEAT]);
         return;
@@ -358,48 +335,45 @@ describe('Client', function() {
       }
     });
 
-    client.on('error', function(err) {
+    client.on('error', function (err) {
       assert.ok(err);
       assert.equal(err, 'ERR_MSG_TYPE');
       assert.equal(true, called);
       done();
     });
 
-    client.on('connect', function() {
-      client.request('foo', 'bar', function(err, data) {
+    client.on('connect', function () {
+      client.request('foo', 'bar', function () {
         assert.ok(false);
-      }, function(err, data) {
+      }, function () {
         assert.ok(false);
       });
-
-      cbCalled = true;
     });
     client.start();
   });
 
 
+  describe('when timeout exceeded with heartbeat short ', function () {
 
-  describe('when timeout exceeded with heartbeat short ', function() {
-
-    before(function() {
+    before(function () {
       clientOpts = {
         heartbeat: 20
       };
     });
 
-    it('emit an error when timeout exceeded', function(done) {
+    it('emit an error when timeout exceeded', function (done) {
 
-      mockBroker.on('message', function(id, clazz, type, topic, rid) {
+      mockBroker.on('message', function (id, clazz, type) {
         if (type.toString() == MDP.W_HEARTBEAT) {
           mockBroker.send([id, clazz, MDP.W_HEARTBEAT]);
           return;
         }
       });
 
-      client.on('connect', function() {
-        client.request('foo', 'bar', function(err, data) {
+      client.on('connect', function () {
+        client.request('foo', 'bar', function () {
           assert.ok(false);
-        }, function(err, data) {
+        }, function (err, data) {
           assert.ok(err);
           assert.equal(data, undefined);
           assert.equal('C_TIMEOUT', err);
@@ -411,36 +385,36 @@ describe('Client', function() {
       client.start();
     });
 
-    after(function() {
+    after(function () {
       clientOpts = undefined;
     });
   });
 
 
-  describe('when timeout exceeded with heartbeat long ', function() {
+  describe('when timeout exceeded with heartbeat long ', function () {
 
-    before(function() {
+    before(function () {
       clientOpts = {
         heartbeat: 50
       };
     });
 
-    it('wait for the heartbeat to expire before the error is returned', function(done) {
+    it('wait for the heartbeat to expire before the error is returned', function (done) {
 
       var cbCalled = false;
 
-      mockBroker.on('message', function(id, clazz, type, topic, rid) {
+      mockBroker.on('message', function (id, clazz, type) {
         if (type.toString() == MDP.W_HEARTBEAT) {
           mockBroker.send([id, clazz, MDP.W_HEARTBEAT]);
           return;
         }
       });
 
-      client.on('connect', function() {
+      client.on('connect', function () {
 
-        client.request('foo', 'bar', function(err, data) {
+        client.request('foo', 'bar', function () {
           assert.ok(false);
-        }, function(err, data) {
+        }, function (err, data) {
           cbCalled = true;
           assert.ok(err);
           assert.equal(data, undefined);
@@ -452,35 +426,35 @@ describe('Client', function() {
 
       client.start();
 
-      setTimeout(function() {
+      setTimeout(function () {
         assert.equal(false, cbCalled);
       }, 30);
 
-      setTimeout(function() {
+      setTimeout(function () {
         assert.equal(true, cbCalled);
         done();
       }, 60);
     });
 
-    after(function() {
+    after(function () {
       clientOpts = undefined;
     });
   });
 
 
-  describe('when heartbeat is setted', function() {
+  describe('when heartbeat is setted', function () {
 
-    before(function() {
+    before(function () {
       clientOpts = {
         heartbeat: 25
       };
     });
 
-    it('send heartbeat regularly', function(done) {
+    it('send heartbeat regularly', function (done) {
 
       var heartbeatCount = 0;
 
-      mockBroker.on('message', function(id, clazz, type, topic, rid) {
+      mockBroker.on('message', function (id, clazz, type) {
         if (type.toString() == MDP.W_HEARTBEAT) {
           mockBroker.send([id, clazz, MDP.W_HEARTBEAT]);
           heartbeatCount++;
@@ -488,10 +462,10 @@ describe('Client', function() {
         }
       });
 
-      client.on('connect', function() {
+      client.on('connect', function () {
         assert.equal(1, heartbeatCount);
 
-        setTimeout(function() {
+        setTimeout(function () {
           assert.equal(3, heartbeatCount);
           done();
         }, 60);
@@ -500,18 +474,18 @@ describe('Client', function() {
       client.start();
     });
 
-    after(function() {
+    after(function () {
       clientOpts = undefined;
     });
   });
 
 
-  it('can send heartbeat from a request, and it will send the good requestId', function(done) {
+  it('can send heartbeat from a request, and it will send the good requestId', function (done) {
 
     var heartbeatCount = 0;
     var requestId;
 
-    mockBroker.on('message', function(id, clazz, type, topic, rid) {
+    mockBroker.on('message', function (id, clazz, type, topic, rid) {
       if (type.toString() == MDP.W_HEARTBEAT && topic == undefined) {
         mockBroker.send([id, clazz, MDP.W_HEARTBEAT]);
         return;
@@ -527,7 +501,7 @@ describe('Client', function() {
         assert.equal(client.conf.name, id.toString());
         assert.equal(MDP.CLIENT, clazz.toString());
         assert.equal(MDP.W_HEARTBEAT, type.toString());
-        assert.equal( requestId , rid.toString());
+        assert.equal(requestId, rid.toString());
       }
 
       if (heartbeatCount == 1) {
@@ -536,7 +510,7 @@ describe('Client', function() {
 
     });
 
-    client.on('connect', function() {
+    client.on('connect', function () {
       var req = client.request('foo', 'bar');
       req.heartbeat();
     });
@@ -545,12 +519,12 @@ describe('Client', function() {
   });
 
 
-  it('can send manual heartbeat for an unknown request', function(done) {
+  it('can send manual heartbeat for an unknown request', function (done) {
 
     var heartbeatCount = 0;
     var heartbeatContent = ['ONE', 'TWO', 'THREE', 'THREE'];
 
-    mockBroker.on('message', function(id, clazz, type, rid) {
+    mockBroker.on('message', function (id, clazz, type, rid) {
       if (type.toString() == MDP.W_HEARTBEAT && rid == undefined) {
         mockBroker.send([id, clazz, MDP.W_HEARTBEAT]);
         return;
@@ -570,7 +544,7 @@ describe('Client', function() {
 
     });
 
-    client.on('connect', function() {
+    client.on('connect', function () {
       client.heartbeat(heartbeatContent[0]);
       client.heartbeat(heartbeatContent[1]);
       client.heartbeat(heartbeatContent[2]);

--- a/test/client.js
+++ b/test/client.js
@@ -21,13 +21,13 @@ describe('Client', function() {
     client = new PIGATO.Client(bhost, clientOpts);
     mockBroker = zmq.socket('router');
     mockBroker.bindSync(bhost);
-  })
+  });
 
   afterEach(function() {
     client.removeAllListeners();
     client.stop();
     mockBroker.unbind(bhost);
-  })
+  });
 
   it('connect to a zmq endpoint and call callback once heartbeat made round trip', function(done) {
 
@@ -118,7 +118,7 @@ describe('Client', function() {
       assert.equal(true, called);
       assert.equal(false, cbCalled);
       done();
-    })
+    });
 
     client.on('connect', function() {
       cbCalled = true;
@@ -177,14 +177,14 @@ describe('Client', function() {
     var partial = false;
 
     client.on('connect', function() {
-       client.request('foo', 'bar', function() {
-        partial = true;
-      }, function(err, data) {
+      client.request('foo', 'bar', function() {
+         partial = true;
+       }, function(err, data) {
         assert.equal(false, partial);
         assert.equal(err, 0);
         assert.equal(data, toAnswer);
         done();
-      })
+      });
     });
     client.start();
   });
@@ -213,7 +213,7 @@ describe('Client', function() {
         assert.equal(data, toAnswer);
       }).on('end', function(err, data) {
         done();
-      })
+      });
     });
     client.start();
   });
@@ -252,7 +252,7 @@ describe('Client', function() {
       }).on('end', function(err, data) {
         assert.equal(3, index);
         done();
-      })
+      });
     });
 
     client.start();
@@ -320,7 +320,7 @@ describe('Client', function() {
   it('emit an ERR_REQ_INVALID error if we send a reply to an invalid request', function(done) {
 
     client.on('error', function(err) {
-      assert.ok(err)
+      assert.ok(err);
       assert.equal(err, 'ERR_REQ_INVALID');
       done();
     
@@ -334,7 +334,7 @@ describe('Client', function() {
       }
     });
     client.on('connect', function() {
-      mockBroker.send([client.conf.name, MDP.CLIENT, MDP.W_REPLY, '', 'MYUNKNOWREQUEST', null, JSON.stringify("bar")]);
+      mockBroker.send([client.conf.name, MDP.CLIENT, MDP.W_REPLY, '', 'MYUNKNOWREQUEST', null, JSON.stringify('bar')]);
 
     });
     client.start();
@@ -359,11 +359,11 @@ describe('Client', function() {
     });
 
     client.on('error', function(err) {
-      assert.ok(err)
+      assert.ok(err);
       assert.equal(err, 'ERR_MSG_TYPE');
       assert.equal(true, called);
       done();
-    })
+    });
 
     client.on('connect', function() {
       client.request('foo', 'bar', function(err, data) {
@@ -385,7 +385,7 @@ describe('Client', function() {
       clientOpts = {
         heartbeat: 20
       };
-    })
+    });
 
     it('emit an error when timeout exceeded', function(done) {
 
@@ -413,7 +413,7 @@ describe('Client', function() {
 
     after(function() {
       clientOpts = undefined;
-    })
+    });
   });
 
 
@@ -423,7 +423,7 @@ describe('Client', function() {
       clientOpts = {
         heartbeat: 50
       };
-    })
+    });
 
     it('wait for the heartbeat to expire before the error is returned', function(done) {
 
@@ -464,7 +464,7 @@ describe('Client', function() {
 
     after(function() {
       clientOpts = undefined;
-    })
+    });
   });
 
 
@@ -474,7 +474,7 @@ describe('Client', function() {
       clientOpts = {
         heartbeat: 25
       };
-    })
+    });
 
     it('send heartbeat regularly', function(done) {
 
@@ -502,7 +502,7 @@ describe('Client', function() {
 
     after(function() {
       clientOpts = undefined;
-    })
+    });
   });
 
 
@@ -527,11 +527,11 @@ describe('Client', function() {
         assert.equal(client.conf.name, id.toString());
         assert.equal(MDP.CLIENT, clazz.toString());
         assert.equal(MDP.W_HEARTBEAT, type.toString());
-        assert.equal( requestId , rid.toString())
+        assert.equal( requestId , rid.toString());
       }
 
       if (heartbeatCount == 1) {
-        done()
+        done();
       }
 
     });
@@ -560,7 +560,7 @@ describe('Client', function() {
         assert.equal(client.conf.name, id.toString());
         assert.equal(MDP.CLIENT, clazz.toString());
         assert.equal(MDP.W_HEARTBEAT, type.toString());
-        assert.equal(heartbeatContent[heartbeatCount], rid.toString())
+        assert.equal(heartbeatContent[heartbeatCount], rid.toString());
         heartbeatCount++;
       }
 
@@ -580,4 +580,4 @@ describe('Client', function() {
     client.start();
   });
 
-})
+});

--- a/test/concurrency.js
+++ b/test/concurrency.js
@@ -2,9 +2,9 @@ var PIGATO = require('../');
 var chai = require('chai');
 var uuid = require('node-uuid');
 
-var location = 'inproc://#';
+//var bhost = 'inproc://#' + uuid.v4();
+var bhost = 'tcp://0.0.0.0:2020';
 
-var bhost = location + uuid.v4();
 var broker = new PIGATO.Broker(bhost);
 
 describe('CONCURRENCY', function () {

--- a/test/concurrency.js
+++ b/test/concurrency.js
@@ -7,7 +7,7 @@ var bhost = 'inproc://#' + uuid.v4();
 
 var broker = new PIGATO.Broker(bhost);
 
-describe('CONCURRENCY', function () {
+describe('CONCURRENCY', function() {
   
   before(function(done) {
     broker.conf.onStart = done;

--- a/test/concurrency.js
+++ b/test/concurrency.js
@@ -2,8 +2,8 @@ var PIGATO = require('../');
 var chai = require('chai');
 var uuid = require('node-uuid');
 
-//var bhost = 'inproc://#' + uuid.v4();
-var bhost = 'tcp://0.0.0.0:2020';
+var bhost = 'inproc://#' + uuid.v4();
+//var bhost = 'tcp://0.0.0.0:2020';
 
 var broker = new PIGATO.Broker(bhost);
 

--- a/test/directory.js
+++ b/test/directory.js
@@ -14,7 +14,7 @@ var brokerConf = {};
 describe('DIRECTORY', function() {
 
   beforeEach(function(done) {
-    brokerConf.intch = "ipc:///tmp/" + uuid.v4();
+    brokerConf.intch = 'ipc:///tmp/' + uuid.v4();
 
     broker = new PIGATO.Broker(bhost, brokerConf);
 
@@ -24,7 +24,7 @@ describe('DIRECTORY', function() {
       });
       ds.conf.onStart = done;
       ds.start();
-    }
+    };
 
     broker.start();
   });
@@ -53,7 +53,7 @@ describe('DIRECTORY', function() {
         });
         worker.start();
         return worker;
-      };
+      }
 
       client.start();
 
@@ -123,7 +123,7 @@ describe('DIRECTORY', function() {
         });
         worker.start();
         return worker;
-      };
+      }
 
       client.start();
 
@@ -177,7 +177,7 @@ describe('DIRECTORY', function() {
         client.stop();
         done(err);
       }
-    })
+    });
   });
 
 });

--- a/test/directory.js
+++ b/test/directory.js
@@ -2,9 +2,8 @@ var PIGATO = require('../');
 var chai = require('chai');
 var uuid = require('node-uuid');
 
-var location = 'inproc://#';
-
-var bhost = location + uuid.v4();
+//var bhost = 'inproc://#' + uuid.v4();
+var bhost = 'tcp://0.0.0.0:2020';
 
 var broker;
 var ds;

--- a/test/directory.js
+++ b/test/directory.js
@@ -2,8 +2,8 @@ var PIGATO = require('../');
 var chai = require('chai');
 var uuid = require('node-uuid');
 
-//var bhost = 'inproc://#' + uuid.v4();
-var bhost = 'tcp://0.0.0.0:2020';
+var bhost = 'inproc://#' + uuid.v4();
+//var bhost = 'tcp://0.0.0.0:2020';
 
 var broker;
 var ds;

--- a/test/index.js
+++ b/test/index.js
@@ -109,8 +109,6 @@ describe('BASE', function() {
     var client = new PIGATO.Client(bhost);
     client.start();
 
-    var repIx = 0;
-
     client.request(
       ns, 'foo',
       undefined,
@@ -319,6 +317,7 @@ describe('BASE', function() {
       undefined,
       function(err, data) {
         chai.assert.equal(err, 'C_TIMEOUT');
+        chai.assert.equal(data, undefined);
         stop();
       }, {
         timeout: 60

--- a/test/index.js
+++ b/test/index.js
@@ -2,9 +2,8 @@ var PIGATO = require('../');
 var chai = require('chai');
 var uuid = require('node-uuid');
 
-var location = 'inproc://#';
-
-var bhost = location + uuid.v4();
+//var bhost = 'inproc://#' + uuid.v4();
+var bhost = 'tcp://0.0.0.0:2020';
 
 var broker = new PIGATO.Broker(bhost)
 

--- a/test/index.js
+++ b/test/index.js
@@ -5,7 +5,7 @@ var uuid = require('node-uuid');
 //var bhost = 'inproc://#' + uuid.v4();
 var bhost = 'tcp://0.0.0.0:2020';
 
-var broker = new PIGATO.Broker(bhost)
+var broker = new PIGATO.Broker(bhost);
 
 describe('BASE', function() {
 
@@ -141,7 +141,7 @@ describe('BASE', function() {
 
       worker.start();
       workers.push(worker);
-    };
+    }
 
     spawn(function(inp, res) {
       res.reject(chunk);
@@ -191,7 +191,7 @@ describe('BASE', function() {
       worker.start();
       workers.push(worker);
       return worker;
-    };
+    }
 
     var client = new PIGATO.Client(bhost);
     client.start();
@@ -293,8 +293,8 @@ describe('BASE', function() {
     client.start();
 
     client.request(ns, 'foo', {
-        timeout: 60
-      })
+      timeout: 60
+    })
       .on('error', function(err) {
         chai.assert.equal(err, 'C_TIMEOUT');
         stop();

--- a/test/index.js
+++ b/test/index.js
@@ -2,8 +2,8 @@ var PIGATO = require('../');
 var chai = require('chai');
 var uuid = require('node-uuid');
 
-//var bhost = 'inproc://#' + uuid.v4();
-var bhost = 'tcp://0.0.0.0:2020';
+var bhost = 'inproc://#' + uuid.v4();
+//var bhost = 'tcp://0.0.0.0:2020';
 
 var broker = new PIGATO.Broker(bhost);
 

--- a/test/requestStream.js
+++ b/test/requestStream.js
@@ -2,9 +2,9 @@ var PIGATO = require('../');
 var chai = require('chai');
 var uuid = require('node-uuid');
 
-var location = 'inproc://#';
+//var bhost = 'inproc://#' + uuid.v4();
+var bhost = 'tcp://0.0.0.0:2020';
 
-var bhost = location + uuid.v4();
 var broker = new PIGATO.Broker(bhost);
 
 describe('STREAM SPECS', function() {

--- a/test/requestStream.js
+++ b/test/requestStream.js
@@ -2,8 +2,8 @@ var PIGATO = require('../');
 var chai = require('chai');
 var uuid = require('node-uuid');
 
-//var bhost = 'inproc://#' + uuid.v4();
-var bhost = 'tcp://0.0.0.0:2020';
+var bhost = 'inproc://#' + uuid.v4();
+//var bhost = 'tcp://0.0.0.0:2020';
 
 var broker = new PIGATO.Broker(bhost);
 

--- a/test/semver.js
+++ b/test/semver.js
@@ -36,8 +36,8 @@ describe('SEMVER', function() {
     var workerId = worker.conf.name;
     client.request(ns, 'foo')
     .on('data', function(data) {
-        chai.assert.equal(data, workerId);
-      })
+      chai.assert.equal(data, workerId);
+    })
       .on('error', function(err) {
         stop(err);
       })

--- a/test/semver.js
+++ b/test/semver.js
@@ -2,8 +2,8 @@ var PIGATO = require('../');
 var chai = require('chai');
 var uuid = require('node-uuid');
 
-var location = 'inproc://#';
-var bhost = location + uuid.v4();
+//var bhost = 'inproc://#' + uuid.v4();
+var bhost = 'tcp://0.0.0.0:2020';
 
 var broker = new PIGATO.Broker(bhost);
 

--- a/test/semver.js
+++ b/test/semver.js
@@ -2,8 +2,8 @@ var PIGATO = require('../');
 var chai = require('chai');
 var uuid = require('node-uuid');
 
-//var bhost = 'inproc://#' + uuid.v4();
-var bhost = 'tcp://0.0.0.0:2020';
+var bhost = 'inproc://#' + uuid.v4();
+//var bhost = 'tcp://0.0.0.0:2020';
 
 var broker = new PIGATO.Broker(bhost);
 

--- a/test/startStop.js
+++ b/test/startStop.js
@@ -121,7 +121,7 @@ describe('StartStop', function() {
     it('call the callback on stop', function(done) {
       worker.conf.onDisconnect = function() {
         client.conf.onDisconnect = done;
-        client.stop()
+        client.stop();
       };
       worker.stop();
     });

--- a/test/startStop.js
+++ b/test/startStop.js
@@ -1,9 +1,6 @@
 var PIGATO = require('../');
 
-var chai = require('chai'),
-  assert = chai.assert;
-var uuid = require('node-uuid');
-
+//var uuid = require('node-uuid');
 //var bhost = 'inproc://#' + uuid.v4();
 var bhost = 'tcp://0.0.0.0:2020';
 

--- a/test/startStop.js
+++ b/test/startStop.js
@@ -4,10 +4,8 @@ var chai = require('chai'),
   assert = chai.assert;
 var uuid = require('node-uuid');
 
-
-var location = 'inproc://#';
-
-var bhost = location + uuid.v4();
+//var bhost = 'inproc://#' + uuid.v4();
+var bhost = 'tcp://0.0.0.0:2020';
 
 var broker = new PIGATO.Broker(bhost, {
   heartbeat: 10000

--- a/test/startStop.js
+++ b/test/startStop.js
@@ -1,8 +1,8 @@
 var PIGATO = require('../');
 
-//var uuid = require('node-uuid');
-//var bhost = 'inproc://#' + uuid.v4();
-var bhost = 'tcp://0.0.0.0:2020';
+var uuid = require('node-uuid');
+var bhost = 'inproc://#' + uuid.v4();
+//var bhost = 'tcp://0.0.0.0:2020';
 
 var broker = new PIGATO.Broker(bhost, {
   heartbeat: 10000

--- a/test/target.js
+++ b/test/target.js
@@ -2,8 +2,8 @@ var PIGATO = require('../');
 var chai = require('chai');
 var uuid = require('node-uuid');
 
-//var bhost = 'inproc://#' + uuid.v4();
-var bhost = 'tcp://0.0.0.0:2020';
+var bhost = 'inproc://#' + uuid.v4();
+//var bhost = 'tcp://0.0.0.0:2020';
 
 var broker = new PIGATO.Broker(bhost);
    

--- a/test/target.js
+++ b/test/target.js
@@ -34,7 +34,7 @@ describe('TARGET', function() {
       });
       worker.start();
       workers.push(worker);
-    };
+    }
 
     client.start();
 
@@ -49,8 +49,8 @@ describe('TARGET', function() {
     function request() {
       var workerId = workers[Math.round(Math.random() * 1000 % 9)].conf.name;
       client.request(ns, 'foo', {
-          workerId: workerId
-        })
+        workerId: workerId
+      })
         .on('data', function(data) {
           chai.assert.equal(data, workerId);
         })
@@ -76,5 +76,5 @@ describe('TARGET', function() {
       client.stop();
       done(err);
     }
-  })
+  });
 });

--- a/test/target.js
+++ b/test/target.js
@@ -2,8 +2,8 @@ var PIGATO = require('../');
 var chai = require('chai');
 var uuid = require('node-uuid');
 
-var location = 'inproc://#';
-var bhost = location + uuid.v4();
+//var bhost = 'inproc://#' + uuid.v4();
+var bhost = 'tcp://0.0.0.0:2020';
 
 var broker = new PIGATO.Broker(bhost);
    

--- a/test/timeout.js
+++ b/test/timeout.js
@@ -29,7 +29,7 @@ describe('TIMEOUT', function() {
     broker.stop();
   });
 
-  describe('When a server is launched', function(done) {
+  describe('When a server is launched', function() {
 
     before(function(done) {
       worker.start();
@@ -47,12 +47,11 @@ describe('TIMEOUT', function() {
         chai.assert.equal(data, chunk + ':bar');
       })
       .on('end', done);
-
     });
   });
 
 
-  describe('When a server is stop', function(done) {
+  describe('When a server is stop', function() {
 
     before(function(done) {
       worker.stop();
@@ -72,7 +71,7 @@ describe('TIMEOUT', function() {
   });
 
 
-  describe('When we launch a server during a request', function(done) {
+  describe('When we launch a server during a request', function() {
 
     it('can reach the server and answer', function(done) {
 
@@ -104,7 +103,7 @@ describe('TIMEOUT', function() {
   });
 
 
-  describe('After that I can do something fast', function(done) {
+  describe('After that I can do something fast', function() {
 
     it('can reach the server and answer', function(done) {
       client.request(ns, chunk, {

--- a/test/wildcards.js
+++ b/test/wildcards.js
@@ -2,9 +2,8 @@ var PIGATO = require('../');
 var assert = require('chai').assert;
 var uuid = require('node-uuid');
 
-var location = 'inproc://#';
-
-var bhost = location + uuid.v4();
+//var bhost = 'inproc://#' + uuid.v4();
+var bhost = 'tcp://0.0.0.0:2020';
 var broker = new PIGATO.Broker(bhost);
 
 var client, worker, ns;

--- a/test/wildcards.js
+++ b/test/wildcards.js
@@ -2,8 +2,8 @@ var PIGATO = require('../');
 var assert = require('chai').assert;
 var uuid = require('node-uuid');
 
-//var bhost = 'inproc://#' + uuid.v4();
-var bhost = 'tcp://0.0.0.0:2020';
+var bhost = 'inproc://#' + uuid.v4();
+//var bhost = 'tcp://0.0.0.0:2020';
 var broker = new PIGATO.Broker(bhost);
 
 var client, worker, ns;

--- a/test/wildcards.js
+++ b/test/wildcards.js
@@ -40,7 +40,7 @@ describe('WILDCARDS', function() {
     afterEach(function() {
       client.stop();
       worker.stop();
-    })
+    });
 
     it('can be reach several times using widlcard mecanisme', function(done) {
       this.timeout(5000);
@@ -48,8 +48,8 @@ describe('WILDCARDS', function() {
 
       function request() {
         client.request(ns + '-' + uuid.v4(), chunk, {
-            timeout: 5000
-          })
+          timeout: 5000
+        })
           .on('data', function(data) {
             assert.equal(data, chunk + ':bar');
           })
@@ -76,7 +76,7 @@ describe('WILDCARDS', function() {
         assert.equal(type, 0);
         assert.equal(data, chunk + ':bar');
         done();
-      })
+      });
     });
   });
 
@@ -106,7 +106,7 @@ describe('WILDCARDS', function() {
       matchingworker.start();
       client.start();
 
-    })
+    });
 
     afterEach(function() {
       matchingworker.stop();
@@ -119,7 +119,7 @@ describe('WILDCARDS', function() {
         assert.equal(type, 0);
         assert.equal(data, 'MATCHING');
         done();
-      })
+      });
     });
   });
 
@@ -147,7 +147,7 @@ describe('WILDCARDS', function() {
       matchingworker.start();
       client.start();
 
-    })
+    });
 
     afterEach(function() {
       matchingworker.stop();
@@ -160,7 +160,7 @@ describe('WILDCARDS', function() {
         assert.equal(type, 0);
         assert.equal(data, 'BEST MATCHING');
         done();
-      })
+      });
     });
   });
 
@@ -188,7 +188,7 @@ describe('WILDCARDS', function() {
       matchingworker.start();
       client.start();
 
-    })
+    });
 
     afterEach(function() {
       matchingworker.stop();
@@ -201,7 +201,7 @@ describe('WILDCARDS', function() {
         assert.equal(type, 0);
         assert.equal(data, 'BEST MATCHING');
         done();
-      })
+      });
     });
   });
 });

--- a/test/worker.js
+++ b/test/worker.js
@@ -21,7 +21,7 @@ describe('Worker', function() {
     worker = new PIGATO.Worker(bhost, workerTopic, workerOpts);
     mockBroker = zmq.socket('router');
     mockBroker.bindSync(bhost);
-  })
+  });
 
   afterEach(function(done) {
 
@@ -33,7 +33,7 @@ describe('Worker', function() {
     });
 
     worker.stop();
-  })
+  });
 
   it('connect to a zmq endpoint and call callback once ready made round trip', function(done) {
 
@@ -101,8 +101,8 @@ describe('Worker', function() {
     mockBroker.send([worker.conf.name, MDP.WORKER, MDP.W_REQUEST]);
 
     worker.socket.on('message', function(a, b, c) {
-      assert.equal(MDP.W_REQUEST, b.toString())
-      countMessage++
+      assert.equal(MDP.W_REQUEST, b.toString());
+      countMessage++;
     });
   });
 
@@ -111,7 +111,7 @@ describe('Worker', function() {
     before(function() {
       workerOpts = {
         heartbeat: 10
-      }
+      };
     });
 
     after(function() {
@@ -120,7 +120,7 @@ describe('Worker', function() {
 
     it('emit hearbeat regularly ', function(done) {
 
-      var heartbeatCount = 0
+      var heartbeatCount = 0;
       var typesIndex = 0;
       var lastDate = new Date();
 
@@ -236,7 +236,7 @@ describe('Worker', function() {
     var received = false;
     
     worker.on('request', function(data, reply) {
-      received = true
+      received = true;
     });
 
     worker.start();
@@ -272,7 +272,7 @@ describe('Worker', function() {
       toCheck = function(a, side, type, clientId) {
         assert.ok(clientId);
         assert.equal(clientId.toString(), 'clientId');
-        done()
+        done();
       };
       mockBroker.send([worker.conf.name, MDP.WORKER, MDP.W_REQUEST, 'clientId', 'service', '', 'requestId']);
     });
@@ -282,7 +282,7 @@ describe('Worker', function() {
         assert.ok(empty);
         assert.equal(empty.length, 0);
         assert.equal(empty.toString().length, 0);
-        done()
+        done();
       };
       mockBroker.send([worker.conf.name, MDP.WORKER, MDP.W_REQUEST, 'clientId', 'service', '', 'requestId']);
     });
@@ -292,7 +292,7 @@ describe('Worker', function() {
         assert.ok(empty);
         assert.equal(empty.length, 0);
         assert.equal(empty.toString().length, 0);
-        done()
+        done();
       };
       mockBroker.send([worker.conf.name, MDP.WORKER, MDP.W_REQUEST, 'clientId', 'service', 'NOTEMPTY', 'requestId']);
     });
@@ -302,7 +302,7 @@ describe('Worker', function() {
       toCheck = function(a, side, type, clientId, service, requestId) {
         assert.ok(requestId);
         assert.equal(requestId.toString(), 'requestId' + rid);
-        done()
+        done();
       };
       mockBroker.send([worker.conf.name, MDP.WORKER, MDP.W_REQUEST, 'clientId', 'service', '', 'requestId' + rid]);
     });
@@ -312,7 +312,7 @@ describe('Worker', function() {
       toCheck = function(a, side, type, clientId, service, requestId, status) {
         assert.ok(status);
         assert.equal(status.toString(), 0);
-        done()
+        done();
       };
       mockBroker.send([worker.conf.name, MDP.WORKER, MDP.W_REQUEST, 'clientId', 'service', '', 'requestId']);
     });
@@ -323,7 +323,7 @@ describe('Worker', function() {
         assert.ok(data);
         assert.ok(data.toString());
         assert.equal(JSON.parse(data.toString()), toAnswer);
-        done()
+        done();
       };
       mockBroker.send([worker.conf.name, MDP.WORKER, MDP.W_REQUEST, 'clientId', 'service', '', 'requestId']);
     });
@@ -345,7 +345,7 @@ describe('Worker', function() {
 
         assert.equal(parsed.foo, 'bar');
         assert.equal(parsed.toto, 42);
-        done()
+        done();
       };
   
       mockBroker.send([worker.conf.name, MDP.WORKER, MDP.W_REQUEST, 'clientId', 'service', '', 'requestId']);
@@ -456,7 +456,7 @@ describe('Worker', function() {
 
     after(function() {
       workerOpts = {};
-    })
+    });
 
     it('requests are still handled in //', function(done) {
 
@@ -595,7 +595,7 @@ describe('Worker Disconnection', function() {
         assert(typesIndex, 3);
         worker.removeAllListeners('disconnect');
         done();
-      })
+      });
 
       worker.start();
     });

--- a/test/z9_system.js
+++ b/test/z9_system.js
@@ -2,9 +2,10 @@ var PIGATO = require('../');
 var zmq = require('zmq');
 var chai = require('chai');
 var assert = chai.assert;
+var uuid = require('node-uuid');
 
-//var bhost = 'inproc://#' + uuid.v4();
-var bhost = 'tcp://0.0.0.0:2020';
+var bhost = 'inproc://#' + uuid.v4();
+//var bhost = 'tcp://0.0.0.0:2020';
 
 var broker = new PIGATO.Broker(bhost);
 

--- a/test/z9_system.js
+++ b/test/z9_system.js
@@ -1,8 +1,6 @@
 var PIGATO = require('../');
 var zmq = require('zmq');
 var chai = require('chai');
-var uuid = require('node-uuid');
-
 var assert = chai.assert;
 
 //var bhost = 'inproc://#' + uuid.v4();

--- a/test/z9_system.js
+++ b/test/z9_system.js
@@ -5,9 +5,8 @@ var uuid = require('node-uuid');
 
 var assert = chai.assert;
 
-var location = 'inproc://#';
-
-var bhost = location + uuid.v4();
+//var bhost = 'inproc://#' + uuid.v4();
+var bhost = 'tcp://0.0.0.0:2020';
 
 var broker = new PIGATO.Broker(bhost);
 

--- a/test/z9_system.js
+++ b/test/z9_system.js
@@ -52,13 +52,13 @@ describe('FILE DESCRIPTORS', function() {
   });*/
 
 
-  describe("When I create lots of sockets", function() {
+  describe('When I create lots of sockets', function() {
 
     before(function(done) {
       setTimeout(done, 100);
     });
 
-    it("still works if I close them in the meantime", function(done) {
+    it('still works if I close them in the meantime', function(done) {
 
       var cnt = 0;
       var step = function() {


### PR DESCRIPTION
I've implemented what I think is an eslint formatting configuration that matches the rules the majority of the code seems to follow. In cases where things were inconsistent (semicolon use, spaces before function params, ...) I went with what the majority of the code seems to do.

I've also made all of the changes required to make it pass, and I've added "npm run lint" as a script. It assumes eslint is installed globally, but I've also added an optional dependency in case users don't want to install it globally.