### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/lib/Broker.js
+++ b/lib/Broker.js
@@ -4,7 +4,7 @@ require('es6-shim');
 
 var util = require('util');
 var debug = require('debug')('pigato:Broker');
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 var events = require('events');
 var zmq = require('zmq');
 var async = require('async');

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -5,7 +5,7 @@ require('es6-shim');
 var zmq = require('zmq');
 var Readable = require('readable-stream').Readable;
 var debug = require('debug')('pigato:Client');
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 var util = require('util');
 var events = require('events');
 var _ = require('lodash');

--- a/lib/Worker.js
+++ b/lib/Worker.js
@@ -5,7 +5,7 @@ require('es6-shim');
 var zmq = require('zmq');
 var Writable = require('readable-stream').Writable;
 var debug = require('debug')('pigato:Worker');
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 var util = require('util');
 var events = require('events');
 var _ = require('lodash');

--- a/package.json
+++ b/package.json
@@ -20,9 +20,9 @@
     "debug": "~2.2.0",
     "es6-shim": "^0.33.13",
     "lodash": "~4.2.1",
-    "node-uuid": "~1.4.7",
     "readable-stream": "2.0.4",
     "semver": "^5.0.3",
+    "uuid": "^3.0.0",
     "zmq": "~2.15.2"
   },
   "engine": {

--- a/test/client.js
+++ b/test/client.js
@@ -6,7 +6,7 @@ var PIGATO = require('../');
 
 var chai = require('chai');
 var assert = chai.assert;
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 
 var location = 'inproc://#';
 var bhost;

--- a/test/concurrency.js
+++ b/test/concurrency.js
@@ -1,6 +1,6 @@
 var PIGATO = require('../');
 var chai = require('chai');
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 
 var bhost = 'inproc://#' + uuid.v4();
 //var bhost = 'tcp://0.0.0.0:2020';

--- a/test/directory.js
+++ b/test/directory.js
@@ -1,6 +1,6 @@
 var PIGATO = require('../');
 var chai = require('chai');
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 
 var bhost = 'inproc://#' + uuid.v4();
 //var bhost = 'tcp://0.0.0.0:2020';

--- a/test/index.js
+++ b/test/index.js
@@ -1,6 +1,6 @@
 var PIGATO = require('../');
 var chai = require('chai');
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 
 var bhost = 'inproc://#' + uuid.v4();
 //var bhost = 'tcp://0.0.0.0:2020';

--- a/test/requestStream.js
+++ b/test/requestStream.js
@@ -1,6 +1,6 @@
 var PIGATO = require('../');
 var chai = require('chai');
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 
 var bhost = 'inproc://#' + uuid.v4();
 //var bhost = 'tcp://0.0.0.0:2020';

--- a/test/semver.js
+++ b/test/semver.js
@@ -1,6 +1,6 @@
 var PIGATO = require('../');
 var chai = require('chai');
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 
 var bhost = 'inproc://#' + uuid.v4();
 //var bhost = 'tcp://0.0.0.0:2020';

--- a/test/startStop.js
+++ b/test/startStop.js
@@ -1,6 +1,6 @@
 var PIGATO = require('../');
 
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 var bhost = 'inproc://#' + uuid.v4();
 //var bhost = 'tcp://0.0.0.0:2020';
 

--- a/test/target.js
+++ b/test/target.js
@@ -1,6 +1,6 @@
 var PIGATO = require('../');
 var chai = require('chai');
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 
 var bhost = 'inproc://#' + uuid.v4();
 //var bhost = 'tcp://0.0.0.0:2020';

--- a/test/timeout.js
+++ b/test/timeout.js
@@ -1,7 +1,7 @@
 var PIGATO = require('../');
 var chai = require('chai'),
   assert = chai.assert;
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 
 var location = 'inproc://#';
 

--- a/test/wildcards.js
+++ b/test/wildcards.js
@@ -1,6 +1,6 @@
 var PIGATO = require('../');
 var assert = require('chai').assert;
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 
 var bhost = 'inproc://#' + uuid.v4();
 //var bhost = 'tcp://0.0.0.0:2020';

--- a/test/worker.js
+++ b/test/worker.js
@@ -6,7 +6,7 @@ var PIGATO = require('../');
 
 var chai = require('chai');
 var assert = chai.assert;
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 
 var location = 'inproc://#';
 var bhost = location + uuid.v4();

--- a/test/z9_system.js
+++ b/test/z9_system.js
@@ -2,7 +2,7 @@ var PIGATO = require('../');
 var zmq = require('zmq');
 var chai = require('chai');
 var assert = chai.assert;
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 
 var bhost = 'inproc://#' + uuid.v4();
 //var bhost = 'tcp://0.0.0.0:2020';


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.