### PR TITLE
fix: Failing CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 env:
-  - ZMQ="git://github.com/zeromq/zeromq4-1.git" ZMQ_VERSION="v4.1.2" SODIUM="git://github.com/jedisct1/libsodium.git" SODIUM_VERSION="1.0.3" CXX=g++-4.8
+- ZMQ="git://github.com/zeromq/zeromq4-1.git" ZMQ_VERSION="v4.1.2" SODIUM="git://github.com/jedisct1/libsodium.git" SODIUM_VERSION="1.0.3" CXX=g++-4.8
 addons:
   apt:
     sources:
@@ -7,26 +7,26 @@ addons:
     packages:
       - g++-4.8
 before_install:
-  - sudo apt-get install uuid-dev
-  - '[ -z "$SODIUM" ] || git clone --depth 1 --no-single-branch $SODIUM libsodium'
-  - '[ -z "$SODIUM" ] || cd libsodium'
-  - '[ -z "$SODIUM" ] || git checkout $SODIUM_VERSION'
-  - '[ -z "$SODIUM" ] || ./autogen.sh'
-  - '[ -z "$SODIUM" ] || ./configure'
-  - '[ -z "$SODIUM" ] || make'
-  - '[ -z "$SODIUM" ] || sudo make install'
-  - '[ -z "$SODIUM" ] || cd ..'
-  - git clone --depth 1 --no-single-branch $ZMQ zmqlib
-  - cd zmqlib
-  - git checkout $ZMQ_VERSION
-  - ./autogen.sh
-  - ./configure
-  - make
-  - sudo make install
-  - sudo /sbin/ldconfig
-  - cd ..
+- sudo apt-get install uuid-dev
+- '[ -z "$SODIUM" ] || git clone --depth 1 --no-single-branch $SODIUM libsodium'
+- '[ -z "$SODIUM" ] || cd libsodium'
+- '[ -z "$SODIUM" ] || git checkout $SODIUM_VERSION'
+- '[ -z "$SODIUM" ] || ./autogen.sh'
+- '[ -z "$SODIUM" ] || ./configure'
+- '[ -z "$SODIUM" ] || make'
+- '[ -z "$SODIUM" ] || sudo make install'
+- '[ -z "$SODIUM" ] || cd ..'
+- git clone --depth 1 --no-single-branch $ZMQ zmqlib
+- cd zmqlib
+- git checkout $ZMQ_VERSION
+- ./autogen.sh
+- ./configure
+- make
+- sudo make install
+- sudo /sbin/ldconfig
+- cd ..
 language: node_js
 node_js:
-  - "4.2"
-  - "5.5"
+- "4.2"
+- "5.5"
 script: travis_retry npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,5 @@
 env:
-    - ZMQ="git://github.com/zeromq/zeromq4-1.git" 
-    - ZMQ_VERSION="v4.1.2" 
-    - SODIUM="git://github.com/jedisct1/libsodium.git" 
-    - SODIUM_VERSION="1.0.3"
-    - CXX=g++-4.8
+  - ZMQ="git://github.com/zeromq/zeromq4-1.git" ZMQ_VERSION="v4.1.2" SODIUM="git://github.com/jedisct1/libsodium.git" SODIUM_VERSION="1.0.3" CXX=g++-4.8
 addons:
   apt:
     sources:
@@ -11,26 +7,26 @@ addons:
     packages:
       - g++-4.8
 before_install:
-    - sudo apt-get install uuid-dev
-    - '[ -z "$SODIUM" ] || git clone --depth 1 --no-single-branch $SODIUM libsodium'
-    - '[ -z "$SODIUM" ] || cd libsodium'
-    - '[ -z "$SODIUM" ] || git checkout $SODIUM_VERSION'
-    - '[ -z "$SODIUM" ] || ./autogen.sh'
-    - '[ -z "$SODIUM" ] || ./configure'
-    - '[ -z "$SODIUM" ] || make'
-    - '[ -z "$SODIUM" ] || sudo make install'
-    - '[ -z "$SODIUM" ] || cd ..'
-    - git clone --depth 1 --no-single-branch $ZMQ zmqlib
-    - cd zmqlib
-    - git checkout $ZMQ_VERSION
-    - ./autogen.sh
-    - ./configure
-    - make
-    - sudo make install
-    - sudo /sbin/ldconfig
-    - cd ..
+  - sudo apt-get install uuid-dev
+  - '[ -z "$SODIUM" ] || git clone --depth 1 --no-single-branch $SODIUM libsodium'
+  - '[ -z "$SODIUM" ] || cd libsodium'
+  - '[ -z "$SODIUM" ] || git checkout $SODIUM_VERSION'
+  - '[ -z "$SODIUM" ] || ./autogen.sh'
+  - '[ -z "$SODIUM" ] || ./configure'
+  - '[ -z "$SODIUM" ] || make'
+  - '[ -z "$SODIUM" ] || sudo make install'
+  - '[ -z "$SODIUM" ] || cd ..'
+  - git clone --depth 1 --no-single-branch $ZMQ zmqlib
+  - cd zmqlib
+  - git checkout $ZMQ_VERSION
+  - ./autogen.sh
+  - ./configure
+  - make
+  - sudo make install
+  - sudo /sbin/ldconfig
+  - cd ..
 language: node_js
 node_js:
-    - "4.2"
-    - "5.5"
+  - "4.2"
+  - "5.5"
 script: travis_retry npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,36 @@
 env:
-- ZMQ="git://github.com/zeromq/zeromq4-1.git -b v4.1.2" SODIUM="git://github.com/jedisct1/libsodium.git -b 1.0.3"
+    - ZMQ="git://github.com/zeromq/zeromq4-1.git" 
+    - ZMQ_VERSION="v4.1.2" 
+    - SODIUM="git://github.com/jedisct1/libsodium.git" 
+    - SODIUM_VERSION="1.0.3"
+    - CXX=g++-4.8
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - g++-4.8
 before_install:
-- sudo apt-get install uuid-dev
-- '[ -z "$SODIUM" ] || git clone --depth 1 $SODIUM libsodium'
-- '[ -z "$SODIUM" ] || cd libsodium'
-- '[ -z "$SODIUM" ] || ./autogen.sh'
-- '[ -z "$SODIUM" ] || ./configure'
-- '[ -z "$SODIUM" ] || make'
-- '[ -z "$SODIUM" ] || sudo make install'
-- '[ -z "$SODIUM" ] || cd ..'
-- git clone --depth 1 $ZMQ zmqlib
-- cd zmqlib
-- ./autogen.sh
-- ./configure
-- make
-- sudo make install
-- sudo /sbin/ldconfig
-- cd ..
+    - sudo apt-get install uuid-dev
+    - '[ -z "$SODIUM" ] || git clone --depth 1 --no-single-branch $SODIUM libsodium'
+    - '[ -z "$SODIUM" ] || cd libsodium'
+    - '[ -z "$SODIUM" ] || git checkout $SODIUM_VERSION'
+    - '[ -z "$SODIUM" ] || ./autogen.sh'
+    - '[ -z "$SODIUM" ] || ./configure'
+    - '[ -z "$SODIUM" ] || make'
+    - '[ -z "$SODIUM" ] || sudo make install'
+    - '[ -z "$SODIUM" ] || cd ..'
+    - git clone --depth 1 --no-single-branch $ZMQ zmqlib
+    - cd zmqlib
+    - git checkout $ZMQ_VERSION
+    - ./autogen.sh
+    - ./configure
+    - make
+    - sudo make install
+    - sudo /sbin/ldconfig
+    - cd ..
 language: node_js
 node_js:
-- "4.2"
-- "5.5"
+    - "4.2"
+    - "5.5"
 script: travis_retry npm test

--- a/lib/Broker.js
+++ b/lib/Broker.js
@@ -583,7 +583,7 @@ Broker.prototype.servicesUpdate = function() {
         return semver.satisfies(version, range);
       });
 
-      service.aux = _.pluck(satisfying, 'name');
+      service.aux = _.map(satisfying, 'name');
     }
   });
 


### PR DESCRIPTION
The CI was failing because the build was relying on specific version
branches to exist.
The development teams of both projects --- ZeroMQ and libsodium ---
created tags for each version and removed the branches.
The branch names were removed from the env vars and new env vars
containing the actual software versions were introduced.
After cloning the code, a separate checkout command is executed. This
command carries out successfully.

Signed-off-by: Adrian Oprea <adrian@oprea.rocks>